### PR TITLE
Fix Makefile typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ serve: ## Run Docs Server
 lint: ## Run linters
 	@$(MAKE) lint-docs
 
-.PHONE: lint-docs
+.PHONY: lint-docs
 lint-docs: ## Lint the documentation for issues
 	@echo ➤ linting docs
 	@docker run --platform=linux/amd64 --rm -it -v $(CURDIR):/code -w /code markdownlint/markdownlint **/*.md


### PR DESCRIPTION
## Summary
- fix `.PHONY` declaration typo for lint-docs target

## Testing
- `npm test` *(fails: sfdx-lwc-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a522dab0832d812139416c2a53c7