### PR TITLE
Add Notify Leader on RSVP Flow

### DIFF
--- a/docs/automation/index.md
+++ b/docs/automation/index.md
@@ -10,6 +10,8 @@ Each automation is designed to reduce manual work, ensure consistency, and suppo
 
 - **[Scheduled: Add Members To Conservation Group](scheduled-add-members-to-conservation-group.md)**  
   Ensures all active site users are part of the Conservation Group and logs changes for audit.
+- **[Notify Leader on RSVP](notify-leader-on-rsvp.md)**  
+  Automatically sends email notifications to event leaders when someone RSVPs "Attending" to their event.
 - [User Sync: Salesforce to Google Workspace](user-sync-google-workspace/index.md)  
   Automates the synchronization of active Salesforce members to Google Workspace accounts.
   - **[User Sync Flow](user-sync-google-workspace/salesforce-flow.md)**

--- a/docs/automation/notify-leader-on-rsvp.md
+++ b/docs/automation/notify-leader-on-rsvp.md
@@ -1,0 +1,261 @@
+# 🔔 Flow: Notify Leader on RSVP
+
+This automated Salesforce Flow sends an email notification to the event leader whenever someone RSVPs "Attending" to an event registration.
+
+---
+
+## Access
+
+* Flow: [Notify Leader on RSVP](https://spokanemountaineers.lightning.force.com/lightning/setup/Flows/home)
+* GitHub: [Notify_Leader_on_RSVP.flow-meta.xml](https://github.com/jasonkradams/smi/blob/main/force-app/main/default/flows/Notify_Leader_on_RSVP.flow-meta.xml)
+
+---
+
+## 🎯 Purpose
+
+This Flow automatically notifies event leaders via email when a member RSVPs to their event. It:
+
+- Triggers automatically when a new `Event_Participant__c` record is created
+- Only processes participants with `Response__c = "Attending"`
+- Retrieves the event leader's email from their associated Contact record
+- Sends a formatted email with event and participant details
+- Includes a direct link to view the event registration in Salesforce
+
+---
+
+## ⚡ Trigger
+
+- **Object**: `Event_Participant__c`
+- **Trigger Type**: Record-Triggered Flow
+- **Trigger Timing**: After Save
+- **Entry Conditions**: 
+  - Record is created (not updated)
+  - `Response__c = "Attending"`
+
+---
+
+## 🧱 Flow Structure
+
+### 1. Get Event Registration
+
+Retrieves the related `Event_Registration__c` record to access:
+- Event name
+- Leader lookup (`Leader__c`)
+- Event start time (`Start__c`)
+- Event location (`Location__c`)
+
+**Element**: `Get_Event_Registration`
+
+---
+
+### 2. Decision: Is Attending?
+
+Checks if the participant's response is "Attending".
+
+**Element**: `Is_Attending`
+
+- ✅ **Response is Attending**: Proceeds to get leader information
+- ❌ **Not Attending**: Flow exits (no email sent)
+
+---
+
+### 3. Get Leader User Record
+
+Retrieves the User record from `Event_Registration__c.Leader__c` to access:
+- User ID
+- User Name (for email greeting)
+- Contact ID (`ContactId`) - used to get the Contact email
+
+**Element**: `Get_Leader`
+
+**Note**: We get the leader's email from their Contact record rather than directly from the User record, as Contact.Email is more reliable for Community users.
+
+---
+
+### 4. Decision: Has Leader?
+
+Validates that a leader is assigned to the event.
+
+**Element**: `Has_Leader`
+
+- ✅ **Leader Exists**: Proceeds to get leader's Contact record
+- ❌ **No Leader**: Flow exits (no email to send)
+
+---
+
+### 5. Get Leader Contact (Parallel with Get Participant Contact)
+
+Retrieves the Contact record associated with the leader User to access:
+- Contact Email (primary email address)
+- Contact Name
+
+**Element**: `Get_Leader_Contact`
+
+This runs in parallel with `Get_Participant_Contact` for efficiency.
+
+---
+
+### 6. Get Participant Contact (Parallel with Get Leader Contact)
+
+Retrieves the Contact record of the person who RSVP'd to include their name in the email.
+
+**Element**: `Get_Participant_Contact`
+
+This runs in parallel with `Get_Leader_Contact` for efficiency.
+
+---
+
+### 7. Decision: Has Leader Email?
+
+Validates that the leader's Contact record has an email address.
+
+**Element**: `Has_Leader_Email`
+
+- ✅ **Email Exists**: Proceeds to send email
+- ❌ **No Email**: Flow exits (cannot send email)
+
+---
+
+### 8. Send Email to Leader
+
+Sends a formatted email to the event leader.
+
+**Element**: `Send_Email_to_Leader`
+
+**Email Subject**:
+```
+New RSVP for {Event Registration Name}
+```
+
+**Email Body**:
+```
+Hi {Leader Name},
+
+A member has RSVP'd for your event.
+
+Event: {Event Registration Name}
+Participant: {Participant Contact Name}
+Response: Attending
+Event Start: {Event Start Date/Time}
+Location: {Event Location}
+
+You can view the event here:
+https://www.spokanemountaineers.org/s/event-registration/{Event Registration ID}
+
+Best regards,
+Spokane Mountaineers
+```
+
+**Email Configuration**:
+- **To**: `Get_Leader_Contact.Email`
+- **From/Sender**: `admin@spokanemountaineers.org` (Org-Wide Email Address)
+- **Sender Type**: `OrgWideEmailAddress`
+
+---
+
+## 🔍 Data Model
+
+### Objects Used
+
+| **Object** | **Purpose** | **Key Fields** |
+|:----------:|:-----------:|:--------------:|
+| `Event_Participant__c` | Trigger record - represents someone RSVPing | `Event_Registration__c`, `Contact__c`, `Response__c` |
+| `Event_Registration__c` | The event being RSVP'd for | `Leader__c`, `Name`, `Start__c`, `Location__c` |
+| `User` | Event leader's user record | `Id`, `Name`, `ContactId` |
+| `Contact` | Leader's contact record (for email) | `Id`, `Email`, `Name` |
+| `Contact` | Participant's contact record (for email content) | `Id`, `Name`, `FirstName`, `LastName` |
+
+### Relationships
+
+- `Event_Participant__c.Event_Registration__c` → `Event_Registration__c` (Master-Detail)
+- `Event_Registration__c.Leader__c` → `User` (Lookup)
+- `User.ContactId` → `Contact` (Lookup)
+- `Event_Participant__c.Contact__c` → `Contact` (Lookup)
+
+---
+
+## ⚠️ Edge Cases Handled
+
+1. **Response is not "Attending"**: Flow exits early, no email sent
+2. **No Leader assigned**: Flow exits if `Event_Registration__c.Leader__c` is null
+3. **Leader has no Contact**: Flow exits if `User.ContactId` is null
+4. **Leader Contact has no Email**: Flow exits if `Contact.Email` is null
+5. **Participant Contact lookup fails**: Flow still continues if participant contact cannot be retrieved (uses available data)
+
+---
+
+## 🔧 Why Use Contact Email Instead of User Email?
+
+This flow intentionally retrieves the email address from the leader's **Contact** record rather than directly from the **User** record. This is because:
+
+- **Community Users**: For Community/Experience Cloud users, the `User.Email` field may not always be reliable or up-to-date
+- **Contact as Source of Truth**: The `Contact.Email` field is typically the primary communication email and is more likely to be current
+- **Consistency**: Using Contact.Email ensures consistent email delivery across standard and community users
+
+The flow retrieves the Contact via `User.ContactId`, then uses `Contact.Email` for the email notification.
+
+---
+
+## 📊 Monitoring & Troubleshooting
+
+### Check Flow Execution
+
+1. Go to **Setup → Flows**
+2. Find **Notify Leader on RSVP**
+3. Click **View Details and Versions**
+4. Click **View** next to the active version
+5. Review **Interview Logs** to see execution history
+
+### Common Issues
+
+| **Issue** | **Possible Cause** | **Solution** |
+|:---------:|:------------------:|:------------:|
+| No email received | Leader Contact missing email | Verify `Contact.Email` is populated for the leader |
+| No email received | Leader User missing ContactId | Verify `User.ContactId` is populated |
+| Flow not triggering | Event Participant created with wrong Response | Verify `Response__c = "Attending"` on new records |
+| Email not sending | Invalid sender address | Verify Org-Wide Email Address `admin@spokanemountaineers.org` is configured and active |
+
+### Verify Email Delivery
+
+- Review Flow Interview logs for errors
+- Verify leader's Contact.Email is valid and active
+- Verify Org-Wide Email Address `admin@spokanemountaineers.org` is configured and active
+- Check email delivery logs in Setup → Email Administration → View Email Logs
+
+---
+
+## 🚀 Future Enhancements
+
+| **Feature** | **Notes** |
+|:-----------:|:---------:|
+| Handle Updates | Currently only triggers on Create. Could add Update trigger to notify when someone changes from "Not Attending" to "Attending" |
+| Email Template | Use Salesforce Email Template instead of hardcoded email body for easier customization |
+| HTML Email | Format email as HTML for better presentation |
+| Bulk RSVP Notification | Option to batch RSVP notifications (e.g., send one email per day with all new RSVPs) |
+| Opt-out Preference | Allow leaders to opt-out of RSVP notifications per event |
+| Participant Count | Include total participant count in the email |
+
+---
+
+## 📝 Related Documentation
+
+- [Event Participant Redirect](../articles/event-participant-redirect.md): Related solution for event participant functionality
+- [Custom Calendar LWC Guide](../how-to-guides/custom-calendar-lwc.md): Documentation on the calendar component used for events
+
+---
+
+## 🛠 Technical Details
+
+- **API Version**: 65.0
+- **Flow Type**: Auto-Launched Flow (Record-Triggered)
+- **Process Type**: RecordAfterSave
+- **Status**: Active
+- **Bulk Support**: Yes (handles multiple Event_Participant__c records created in same transaction)
+- **Maintainability**: Each flow element includes a description explaining its purpose and intent for easier future maintenance
+
+---
+
+## 📞 Support
+
+For issues or questions about this flow, contact the tech team at [webdev@spokanemountaineers.org](mailto:webdev@spokanemountaineers.org).
+

--- a/force-app/main/default/flows/Notify_Leader_on_RSVP.flow-meta.xml
+++ b/force-app/main/default/flows/Notify_Leader_on_RSVP.flow-meta.xml
@@ -1,0 +1,270 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <decisions>
+        <name>Is_Attending</name>
+        <label>Is Attending?</label>
+        <description>Checks if the participant's Response__c field equals "Attending". Only sends notifications for attending participants, not for "Not Attending" or other response types.</description>
+        <locationX>264</locationX>
+        <locationY>398</locationY>
+        <defaultConnectorLabel>Not Attending</defaultConnectorLabel>
+        <rules>
+            <name>Response_is_Attending</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>$Record.Response__c</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Attending</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Get_Leader</targetReference>
+            </connector>
+            <label>Response is Attending</label>
+        </rules>
+    </decisions>
+    <decisions>
+        <name>Has_Leader</name>
+        <label>Has Leader?</label>
+        <description>Verifies that the Event Registration has a Leader__c assigned. Prevents attempting to send emails when no leader is configured for the event.</description>
+        <locationX>264</locationX>
+        <locationY>614</locationY>
+        <defaultConnectorLabel>No Leader</defaultConnectorLabel>
+        <rules>
+            <name>Leader_Exists</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Get_Event_Registration.Leader__c</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>false</booleanValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Get_Participant_Contact</targetReference>
+            </connector>
+            <label>Leader Exists</label>
+        </rules>
+    </decisions>
+    <decisions>
+        <name>Has_Leader_Email</name>
+        <label>Has Leader Email?</label>
+        <description>Checks if the leader's Contact record has a valid email address. This is a safety check to prevent sending emails to invalid/null addresses.</description>
+        <locationX>264</locationX>
+        <locationY>830</locationY>
+        <defaultConnectorLabel>No Email</defaultConnectorLabel>
+        <rules>
+            <name>Email_Exists</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Get_Leader_Contact.Email</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>false</booleanValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Send_Email_to_Leader</targetReference>
+            </connector>
+            <label>Email Exists</label>
+        </rules>
+    </decisions>
+    <environments>Default</environments>
+    <description>Automatically sends an email notification to the Event Leader when a member RSVPs as "Attending" for their event. The flow retrieves the leader's email from their Contact record for better reliability than using the User.Email field.</description>
+    <interviewLabel>Notify Leader on RSVP {!$Flow.CurrentDateTime}</interviewLabel>
+    <label>Notify Leader on RSVP</label>
+    <processMetadataValues>
+        <name>BuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>AUTO_LAYOUT_CANVAS</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>OriginBuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>OfflineBuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processType>AutoLaunchedFlow</processType>
+    <recordLookups>
+        <name>Get_Event_Registration</name>
+        <label>Get Event Registration</label>
+        <description>Retrieves the Event_Registration__c record associated with the Event_Participant__c. Fetches event details (Name, Leader__c, Start__c, Location__c) needed for the email notification.</description>
+        <locationX>264</locationX>
+        <locationY>182</locationY>
+        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
+        <connector>
+            <targetReference>Is_Attending</targetReference>
+        </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Id</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>$Record.Event_Registration__c</elementReference>
+            </value>
+        </filters>
+        <getFirstRecordOnly>true</getFirstRecordOnly>
+        <object>Event_Registration__c</object>
+        <queriedFields>Id</queriedFields>
+        <queriedFields>Leader__c</queriedFields>
+        <queriedFields>Name</queriedFields>
+        <queriedFields>Start__c</queriedFields>
+        <queriedFields>Location__c</queriedFields>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordLookups>
+    <recordLookups>
+        <name>Get_Leader</name>
+        <label>Get Leader</label>
+        <description>Retrieves the User record of the Event Leader using the Leader__c lookup from the Event Registration. Queries for Name and ContactId to later get the leader's email from their Contact record.</description>
+        <locationX>264</locationX>
+        <locationY>506</locationY>
+        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
+        <connector>
+            <targetReference>Has_Leader</targetReference>
+        </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Id</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>Get_Event_Registration.Leader__c</elementReference>
+            </value>
+        </filters>
+        <getFirstRecordOnly>true</getFirstRecordOnly>
+        <object>User</object>
+        <queriedFields>Id</queriedFields>
+        <queriedFields>Name</queriedFields>
+        <queriedFields>ContactId</queriedFields>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordLookups>
+    <recordLookups>
+        <name>Get_Leader_Contact</name>
+        <label>Get Leader Contact</label>
+        <description>Retrieves the Contact record associated with the Leader's User record. This is done because Contact.Email is more reliable for external communications than User.Email, especially when users have Contact records linked to their User accounts.</description>
+        <locationX>264</locationX>
+        <locationY>722</locationY>
+        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
+        <connector>
+            <targetReference>Has_Leader_Email</targetReference>
+        </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Id</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>Get_Leader.ContactId</elementReference>
+            </value>
+        </filters>
+        <getFirstRecordOnly>true</getFirstRecordOnly>
+        <object>Contact</object>
+        <queriedFields>Id</queriedFields>
+        <queriedFields>Email</queriedFields>
+        <queriedFields>Name</queriedFields>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordLookups>
+    <recordLookups>
+        <name>Get_Participant_Contact</name>
+        <label>Get Participant Contact</label>
+        <description>Retrieves the Contact record of the participant who RSVP'd. This information is included in the email to the leader so they know who registered for their event.</description>
+        <locationX>120</locationX>
+        <locationY>722</locationY>
+        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
+        <connector>
+            <targetReference>Get_Leader_Contact</targetReference>
+        </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Id</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>$Record.Contact__c</elementReference>
+            </value>
+        </filters>
+        <getFirstRecordOnly>true</getFirstRecordOnly>
+        <object>Contact</object>
+        <queriedFields>Id</queriedFields>
+        <queriedFields>Name</queriedFields>
+        <queriedFields>FirstName</queriedFields>
+        <queriedFields>LastName</queriedFields>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordLookups>
+    <start>
+        <locationX>50</locationX>
+        <locationY>0</locationY>
+        <connector>
+            <targetReference>Get_Event_Registration</targetReference>
+        </connector>
+        <object>Event_Participant__c</object>
+        <recordTriggerType>Create</recordTriggerType>
+        <triggerType>RecordAfterSave</triggerType>
+    </start>
+    <status>Active</status>
+    <actionCalls>
+        <name>Send_Email_to_Leader</name>
+        <label>Send Email to Leader</label>
+        <description>Sends an email notification to the event leader with details about the new RSVP. Includes event name, participant name, event start time, location, and a link to view the event registration in Salesforce.</description>
+        <locationX>572</locationX>
+        <locationY>938</locationY>
+        <actionName>emailSimple</actionName>
+        <actionType>emailSimple</actionType>
+        <flowTransactionModel>CurrentTransaction</flowTransactionModel>
+        <inputParameters>
+            <name>emailAddresses</name>
+            <value>
+                <elementReference>Get_Leader_Contact.Email</elementReference>
+            </value>
+        </inputParameters>
+        <inputParameters>
+            <name>emailBody</name>
+            <value>
+                <stringValue>Hi {!Get_Leader.Name},
+
+A member has RSVP'd for your event.
+
+Event: {!Get_Event_Registration.Name}
+Participant: {!Get_Participant_Contact.Name}
+Response: {!$Record.Response__c}
+Event Start: {!Get_Event_Registration.Start__c}
+Location: {!Get_Event_Registration.Location__c}
+
+You can view the event here:
+https://www.spokanemountaineers.org/s/event-registration/{!Get_Event_Registration.Id}
+
+Best regards,
+Spokane Mountaineers</stringValue>
+            </value>
+        </inputParameters>
+        <inputParameters>
+            <name>emailSubject</name>
+            <value>
+                <stringValue>New RSVP for {!Get_Event_Registration.Name}</stringValue>
+            </value>
+        </inputParameters>
+        <inputParameters>
+            <name>senderAddress</name>
+            <value>
+                <stringValue>admin@spokanemountaineers.org</stringValue>
+            </value>
+        </inputParameters>
+        <inputParameters>
+            <name>senderType</name>
+            <value>
+                <stringValue>OrgWideEmailAddress</stringValue>
+            </value>
+        </inputParameters>
+    </actionCalls>
+</Flow>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
         - Google App Script:
           - automation/user-sync-google-workspace/google-app-script/index.md
     - Scheduled Add Aembers to Conservation Group: automation/scheduled-add-members-to-conservation-group.md
+    - Notify Leader on RSVP: automation/notify-leader-on-rsvp.md
   - About: about.md  # We'll add this page later.
 
 # Custom branding


### PR DESCRIPTION
## Summary

This PR adds a new Salesforce Flow that automatically sends email notifications to event leaders whenever someone RSVPs "Attending" to an event.

## Changes

- **New Flow**: `Notify_Leader_on_RSVP` - Record-Triggered Flow that runs when a new Event_Participant__c record is created with Response__c = "Attending"
- **Email Configuration**: Uses Org-Wide Email Address (admin@spokanemountaineers.org) as sender
- **Reliability**: Retrieves leader email from Contact record instead of User record for better reliability with Community users
- **Documentation**: Comprehensive documentation article with flow structure, troubleshooting guide, and technical details
- **Maintainability**: All flow elements include descriptions explaining their purpose and intent

## Flow Features

- Triggers on Event_Participant__c creation with "Attending" response
- Retrieves event registration and leader information
- Gets leader email from Contact record (via User.ContactId)
- Sends formatted email with event and participant details
- Includes direct link to event registration page

## Testing

- Flow has been deployed and activated in webdev5@spokanemountaineers.org
- All flow warnings have been resolved
- Documentation reviewed and updated to match implementation