### PR TITLE
fix(auth): shorten Google login error message to prevent URL parameter overflow

### DIFF
--- a/force-app/main/default/classes/GoogleAuthRegistrationHandler.cls
+++ b/force-app/main/default/classes/GoogleAuthRegistrationHandler.cls
@@ -54,13 +54,7 @@ public class GoogleAuthRegistrationHandler implements Auth.RegistrationHandler {
         System.debug('ERROR: No existing user found for email: ' + data.email);
         System.debug('User must register through Donorbox before using Google login');
         
-        String errorMessage = 'No account found for this email address.\n\n' +
-            'If you are a new member, please sign up at:\n' +
-            'https://donorbox.org/spokanemountaineers-membership-2\n\n' +
-            'If you already have an account, please:\n' +
-            '1. Use your usual login method for now\n' +
-            '2. Report this issue to webdev@spokanemountaineers.org\n\n' +
-            'We will help you link your Google account to your existing membership.';
+        String errorMessage = 'No account found. New members: sign up at donorbox.org/spokanemountaineers-membership-2. Existing members: contact webdev@spokanemountaineers.org to link your Google account.';
         
         throw new RegistrationHandlerException(errorMessage);
     }


### PR DESCRIPTION
## Problem

The error message thrown when a user attempts to sign in with Google but doesn't have an account was too long (~300+ characters with newlines) and contained special characters. This caused the AuthorizationError page to fail when Salesforce tried to pass the error message as a URL parameter, resulting in a page rendering error instead of showing the helpful error message to the user.

## Solution

Shortened the error message in `GoogleAuthRegistrationHandler` to be URL-safe while preserving all essential information:

- Reduced from 300+ characters to 174 characters
- Removed newline characters (`\n`) that caused URL encoding issues
- Removed `https://` prefix from URL
- Condensed to a single line while maintaining actionable guidance

## Changes

- Updated `force-app/main/default/classes/GoogleAuthRegistrationHandler.cls`
- Error message now fits within URL parameter limits and displays correctly

## New Error Message

```
No account found. New members: sign up at donorbox.org/spokanemountaineers-membership-2. Existing members: contact webdev@spokanemountaineers.org to link your Google account.
```