### PR TITLE
fix: LicenseShuffleBatch two-pass rewrite + emergency license recovery

### DIFF
--- a/docs/plans/2026-04-12-fix-license-shuffle-batch.md
+++ b/docs/plans/2026-04-12-fix-license-shuffle-batch.md
@@ -1,0 +1,149 @@
+# Fix License Shuffle Batch — Emergency Downgrade & Algorithm Rewrite Plan
+
+## Context
+
+The `LicenseShuffleBatch` has been running daily since approximately December 2025. As of 2026-04-12:
+
+- **505 Customer Community Plus (Premium) licenses assigned** — this is the hard cap
+- **171 non-protected Premium users have ≤5 logins** in the current fiscal period — the batch should be downgrading these users but isn't
+- The batch runs without errors (21 chunks, 0 errors/day), making only 1–3 changes per run
+- The daily scheduler (`Login History Sync - Daily`) has triggered 120 times and is healthy
+- `Fiscal_Year_Login_History__c` has 25,069 records and is being maintained correctly
+
+The root cause is a two-pass correctness bug in `LicenseShuffleBatch`: license decisions are made per-chunk on incomplete data, because `calculatePremiumUsersToKeep()` is called before all users have been collected.
+
+---
+
+## Phase 1: Emergency Script (run immediately)
+
+**Goal**: Free up 30 Premium licenses now by directly downgrading the 30 non-protected Premium users with the fewest logins.
+
+**File**: `scripts/apex/license-sorting/emergency_downgrade_bottom_30.apex`
+
+**Logic**:
+
+1. Determine fiscal year date range (same logic as `countUserLogins()` — last 365 days for Feb–Apr, Feb 1 of current year for May–Dec, Feb 1 of prior year for Jan)
+2. Aggregate login counts from `Fiscal_Year_Login_History__c` grouped by user
+3. Query all active Premium users who are not protected (not Chair profile, created >90 days ago)
+4. Sort ascending by login count, take the bottom 30
+5. Update their `ProfileId` to `SM Community Plus Login`
+6. Enqueue `LicenseChangeLogQueueable` with reason `"Emergency downgrade - license cap exceeded"`
+
+**Verification after run**:
+
+```
+SELECT Profile.UserLicense.Name, COUNT(Id)
+FROM User
+WHERE IsActive = true
+AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
+GROUP BY Profile.UserLicense.Name
+```
+
+Expected: Premium count drops from 505 to 475.
+
+---
+
+## Phase 2: LicenseShuffleBatch Algorithm Rewrite
+
+### Problem: Single-pass per-chunk decision making
+
+The batch processes ~50 users per chunk. On each chunk, `calculatePremiumUsersToKeep()` runs against only the users seen so far (`allUsers` map). Users in early chunks get their licenses changed before later chunks have been seen, so the keep list is built on partial data.
+
+Additionally:
+
+- `targetCalculated` flag is initialized `false` and **never set to `true`** — the recalculation branch on line 91 is dead code
+- `getProfileId()` issues a SOQL query per user update (inside a loop)
+- `countUserLogins()` issues one `COUNT()` SOQL query per user (50 queries/chunk)
+
+### Fix: Two-pass design
+
+Separate the batch into a **collection phase** (execute) and an **action phase** (finish).
+
+**`execute()`** — collect only, no DML:
+
+- Cast scope to `List<User>`, add to `allUsers` stateful map
+- Identify protected users, add to `protectedUserIds`
+- Run a single aggregate SOQL query for login counts for all users in this chunk (GROUP BY User\_\_c), merge results into `userLoginCounts` stateful map
+- No license changes, no profile lookups
+
+**`finish()`** — act on complete data:
+
+1. Query and cache needed Profile IDs (`SM Community Plus Login`, `SM Community Plus Member`) — two SOQL queries total
+2. Call `calculatePremiumUsersToKeep()` once with full `allUsers` and `userLoginCounts`
+3. Iterate `allUsers.values()`, build `List<User>` of changes
+4. `update usersToUpdate` (all at once, within 10k DML row limit — we have ~1007 users)
+5. Enqueue `LicenseChangeLogQueueable` with accumulated logs
+
+**Remove**:
+
+- `targetCalculated` flag (dead code)
+- `collectionPhaseComplete` flag (unused)
+- `premiumUsersToKeep` calculation from `execute()`
+- `getProfileId()` method (replace with cached map in `finish()`)
+
+**Result**: The algorithm sees all users before making any decisions, which is the correct behavior.
+
+### Fix: Batch login count query
+
+Replace the per-user `countUserLogins()` SOQL with a single aggregate query per chunk:
+
+```apex
+// In execute(): one query for the whole chunk
+Set<Id> chunkUserIds = new Set<Id>();
+for (User u : users) chunkUserIds.add(u.Id);
+
+AggregateResult[] counts = [
+    SELECT User__c uid, COUNT(Id) cnt
+    FROM Fiscal_Year_Login_History__c
+    WHERE User__c IN :chunkUserIds
+    AND Login_Time__c >= :startDateTime
+    GROUP BY User__c
+];
+for (AggregateResult ar : counts) {
+    userLoginCounts.put((Id)ar.get('uid'), (Integer)ar.get('cnt'));
+}
+// Users with no records default to 0 (already handled by map miss)
+```
+
+This reduces SOQL queries from 50/chunk to 1/chunk.
+
+---
+
+## Phase 3: LoginHistoryCleanupBatch — Add Database.Stateful
+
+`LoginHistoryCleanupBatch` tracks `totalRecordsDeleted` and `totalErrors` across chunks but does not implement `Database.Stateful`. These counters reset between chunks. The `finish()` summary always reports 0.
+
+**Fix**: Add `Database.Stateful` to the class declaration.
+
+---
+
+## Phase 4: Update Proposal Doc
+
+Update `docs/proposals/automate-member-license-sorting.md`:
+
+- Mark all Phase 4 and Phase 5 items as complete (schedulers have been running ~4 months)
+- Update status from "Ready for Deployment" to "Live — Deployed"
+- Note the algorithm bug and this fix plan
+- Remove deployment steps that are already done
+
+---
+
+## Implementation Order
+
+1. **Run emergency script** — immediate, no deploy needed ✅ (script written, ready to run)
+2. **Rewrite `LicenseShuffleBatch`** — fix execute/finish split, batch login queries, remove dead code ✅
+3. **Fix `LoginHistoryCleanupBatch`** — add `Database.Stateful` ✅
+4. **Update tests** — removed four dead-code tests, 240/240 passing ✅
+5. **Deploy to org** — deployed 2026-04-12, 240/240 org tests passing ✅
+6. **Reschedule daily sync** — rescheduled after deploy, next fire 2026-04-13 09:00 ✅
+7. **Update proposal doc** ✅
+
+---
+
+## Success Criteria
+
+- Premium license count at or below 475 after emergency script — **pending: run emergency_downgrade_bottom_30.apex**
+- Next daily batch run (2026-04-13 09:00) makes correct decisions (downgrades all users with ≤5 logins)
+- Batch `finish()` debug log shows correct total counts
+- `LoginHistoryCleanupBatch` finish log shows accurate deleted count
+- All existing tests pass ✅

--- a/docs/proposals/automate-member-license-sorting.md
+++ b/docs/proposals/automate-member-license-sorting.md
@@ -1,6 +1,6 @@
 # Automating Member License Sorting
 
-**Status**: Ready for Deployment  
+**Status**: Live — Active bug under remediation (see [fix plan](../plans/2026-04-12-fix-license-shuffle-batch.md))
 **Created**: 2025-12-08  
 **Author**: Jason Adams  
 **Related Issue**: [#42](https://github.com/jasonkradams/smi/issues/42)
@@ -242,18 +242,24 @@ All license changes are logged to `License_Change_Log__c` with:
 - [x] Create FLS grant script for field-level security setup
 - [x] Run FLS grant script to set permissions
 - [x] Run initial data migration (LoginHistoryMigrationBatch) to backfill last 6 months
-- [ ] Schedule `LoginHistorySyncScheduler` to run daily
-- [ ] Schedule `LoginHistoryCleanupScheduler` to run annually on May 1st
-- [ ] Monitor initial runs and verify functionality
-- [ ] Deploy to production after testing complete
+- [x] Schedule `LoginHistorySyncScheduler` to run daily (running since ~Dec 2025, 120+ triggers)
+- [x] Deploy to production
 
 ### Phase 5: Documentation
 
 - [x] Document system architecture and components
 - [x] Document Queueable class and MIXED_DML workaround
 - [x] Document setup scripts and deployment steps
-- [ ] Create admin guide for monitoring
-- [ ] Document troubleshooting procedures
+
+### Phase 6: Bug Fix (active)
+
+See [fix plan](../plans/2026-04-12-fix-license-shuffle-batch.md).
+
+- [ ] Emergency script: downgrade bottom 30 Premium users to relieve license cap
+- [ ] Rewrite `LicenseShuffleBatch` with two-pass design (collect in execute, act in finish)
+- [ ] Fix `LoginHistoryCleanupBatch`: add `Database.Stateful`
+- [ ] Update test classes for new batch structure
+- [ ] Deploy fixes and verify steady state
 
 ## Implementation Notes
 
@@ -325,4 +331,8 @@ All license changes are logged to `License_Change_Log__c` with:
 
 ## Status
 
-System is implemented and ready for production deployment. All components have been deployed to staging and tested. Initial data migration has been completed. System awaits scheduling of daily sync and annual cleanup jobs, followed by production deployment after final testing verification.
+System is live in production. As of 2026-04-12:
+
+- `Login History Sync - Daily` scheduler has been running since ~Dec 2025 (120+ triggers)
+- `Fiscal_Year_Login_History__c` has 25,069 records
+- **Active issue**: `LicenseShuffleBatch` has a two-pass correctness bug causing it to make license decisions per-chunk before all users are visible. As a result, 171 non-protected Premium users with ≤5 logins remain on Premium licenses and the hard cap of 505 has been reached. An emergency downgrade script and batch rewrite are underway — see [fix plan](../plans/2026-04-12-fix-license-shuffle-batch.md).

--- a/force-app/main/default/classes/LicenseShuffleBatch.cls
+++ b/force-app/main/default/classes/LicenseShuffleBatch.cls
@@ -1,448 +1,333 @@
 /**
  * Batch class for optimizing Salesforce Community license usage.
- * 
- * Assigns Premium licenses to users with >5 logins, up to a maximum of 475 Premium licenses.
- * Protected users (Chairs and new users <90 days old) always get Premium licenses.
- * 
- * Runs daily to ensure license assignments reflect current login activity.
- * Uses Fiscal_Year_Login_History__c to track full fiscal year (Feb 1 - Jan 31) login counts.
+ *
+ * Uses a two-pass design:
+ *   execute() — collection phase only. Accumulates all users and login counts.
+ *               No DML, no license decisions.
+ *   finish()  — action phase. Sees all users before making any decisions.
+ *               Calculates keep list, updates licenses, enqueues audit logs.
+ *
+ * Assigns Premium licenses to users with >5 logins, up to a maximum of 475.
+ * Protected users (Chairs and new users <90 days old) always keep Premium.
+ *
+ * Runs daily via LoginHistorySyncBatch.finish() → Database.executeBatch().
+ * Uses Fiscal_Year_Login_History__c for full fiscal year (Feb 1 – Jan 31) counts.
  */
 public class LicenseShuffleBatch implements Database.Batchable<sObject>, Database.Stateful {
-    
-    private static final Integer MAX_PREMIUM_LICENSES = 475;
-    private static final Integer LOGIN_THRESHOLD = 5; // Users with >5 logins qualify for Premium
-    private static final Integer NEW_USER_DAYS = 90;
-    private static final String CHAIR_PROFILE = 'SM Community Plus Chair';
-    private static final String PREMIUM_PROFILE = 'SM Community Plus Member';
-    private static final String LOGIN_PROFILE = 'SM Community Plus Login';
-    private static final String PREMIUM_LICENSE = 'Customer Community Plus';
-    private static final String LOGIN_LICENSE = 'Customer Community Plus Login';
-    
-    // Stateful variables to track across batch chunks
-    private Set<Id> protectedUserIds = new Set<Id>();
-    private Map<Id, Integer> userLoginCounts = new Map<Id, Integer>();
-    private Map<Id, User> allUsers = new Map<Id, User>(); // All Community users (Premium and Login) across all chunks
-    private List<License_Change_Log__c> changeLogs = new List<License_Change_Log__c>();
-    private Integer totalUsersProcessed = 0;
-    private Integer totalChanges = 0;
-    private String batchJobId;
-    private Boolean targetCalculated = false;
-    private Set<Id> premiumUsersToKeep = new Set<Id>(); // Users who should have Premium licenses (max 475)
-    private Boolean collectionPhaseComplete = false; // Track if we've finished collecting all users
-    
-    /**
-     * Batch start method - queries all active Community users
-     */
-    public Database.QueryLocator start(Database.BatchableContext bc) {
-        batchJobId = bc.getJobId();
-        System.debug('LicenseShuffleBatch: Starting batch job ' + batchJobId);
-        
-        // Query all active users with Customer Community Plus or Customer Community Plus Login licenses
-        return Database.getQueryLocator([
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN (:PREMIUM_LICENSE, :LOGIN_LICENSE)
-            ORDER BY Profile.UserLicense.Name, CreatedDate DESC
-        ]);
-    }
-    
-    /**
-     * Batch execute method - processes users, counts logins, and identifies candidates
-     */
-    public void execute(Database.BatchableContext bc, List<sObject> scope) {
-        if (scope == null || scope.isEmpty()) {
-            System.debug('LicenseShuffleBatch: No users to process in this batch');
-            return;
-        }
-        
-        // Cast scope to List<User>
-        List<User> users = new List<User>();
-        for (sObject obj : scope) {
-            users.add((User)obj);
-        }
-        
-        System.debug('LicenseShuffleBatch: Processing ' + users.size() + ' users');
-        totalUsersProcessed += users.size();
-        
-        // First pass: Identify protected users, count logins, and collect all users
-        for (User u : users) {
-            // Identify protected users (Chairs and new users <90 days old)
-            if (u.Profile.Name == CHAIR_PROFILE || isNewUser(u.CreatedDate)) {
-                protectedUserIds.add(u.Id);
-            }
-            
-            // Count logins for each user
-            Integer loginCount = countUserLogins(u.Id);
-            userLoginCounts.put(u.Id, loginCount);
-            
-            // Collect all users (both Premium and Login) for later calculation
-            allUsers.put(u.Id, u);
-        }
-        
-        // Calculate which users should have Premium licenses (max 475)
-        // This considers ALL users together and selects users with >5 logins, up to 475 total
-        // Protected users always get Premium, then remaining slots filled by users with >5 logins
-        // sorted by login count (descending)
-        if (!targetCalculated) {
-            // First time: calculate based on what we have so far, but mark that we'll recalculate
-            premiumUsersToKeep = calculatePremiumUsersToKeep();
-            System.debug('LicenseShuffleBatch: Initial calculation - keeping ' + premiumUsersToKeep.size() + ' users as Premium out of ' + allUsers.size() + ' total users');
-        } else if (allUsers.size() > premiumUsersToKeep.size() * 1.5) {
-            // Recalculate if we've discovered significantly more users
-            // This handles the case where users are distributed across chunks
-            premiumUsersToKeep = calculatePremiumUsersToKeep();
-            System.debug('LicenseShuffleBatch: Recalculated - keeping ' + premiumUsersToKeep.size() + ' users as Premium out of ' + allUsers.size() + ' total users');
-        }
-        
-        // Second pass: Identify candidates and execute changes
-        List<User> usersToUpdate = new List<User>();
-        
-        for (User u : users) {
-            String currentLicense = u.Profile.UserLicense.Name;
-            Integer loginCount = userLoginCounts.get(u.Id);
-            
-            // Skip protected users - they never change
-            if (protectedUserIds.contains(u.Id)) {
-                System.debug('LicenseShuffleBatch: Skipping protected user ' + u.Id + ' (login count: ' + loginCount + ')');
-                continue;
-            }
-            
-            // Determine if user needs license change
-            if (currentLicense == PREMIUM_LICENSE) {
-                // Premium user: downgrade if not in keep list
-                if (!premiumUsersToKeep.contains(u.Id)) {
-                    // Downgrade to Login license
-                    System.debug('LicenseShuffleBatch: Downgrading user ' + u.Id + ' from Premium to Login (login count: ' + loginCount + ', in keep list: ' + premiumUsersToKeep.contains(u.Id) + ')');
-                    User userToUpdate = new User(Id = u.Id);
-                    userToUpdate.ProfileId = getProfileId(LOGIN_PROFILE);
-                    usersToUpdate.add(userToUpdate);
-                    
-                    // Create log record
-                    createChangeLog(u, PREMIUM_LICENSE, LOGIN_LICENSE, 
-                                   u.Profile.Name, LOGIN_PROFILE, loginCount, 'Low usage');
-                } else {
-                    System.debug('LicenseShuffleBatch: Keeping user ' + u.Id + ' as Premium (login count: ' + loginCount + ')');
-                }
-            } else if (currentLicense == LOGIN_LICENSE) {
-                // Login user: upgrade if they're in the Premium keep list
-                // The keep list includes protected users and users with >5 logins (up to 475 max)
-                if (premiumUsersToKeep.contains(u.Id)) {
-                    // Upgrade to Premium license
-                    System.debug('LicenseShuffleBatch: Upgrading user ' + u.Id + ' from Login to Premium (login count: ' + loginCount + ')');
-                    User userToUpdate = new User(Id = u.Id);
-                    userToUpdate.ProfileId = getProfileId(PREMIUM_PROFILE);
-                    usersToUpdate.add(userToUpdate);
-                    
-                    // Create log record
-                    createChangeLog(u, LOGIN_LICENSE, PREMIUM_LICENSE,
-                                   u.Profile.Name, PREMIUM_PROFILE, loginCount, 'High usage');
-                    System.debug('LicenseShuffleBatch: Created upgrade log for user ' + u.Id + ' (Login -> Premium, login count: ' + loginCount + ')');
-                } else {
-                    System.debug('LicenseShuffleBatch: Keeping user ' + u.Id + ' as Login (login count: ' + loginCount + ', not in Premium keep list)');
-                }
-            }
-        }
-        
-        // Update users
-        if (!usersToUpdate.isEmpty()) {
-            try {
-                update usersToUpdate;
-                totalChanges += usersToUpdate.size();
-                System.debug('LicenseShuffleBatch: Updated ' + usersToUpdate.size() + ' users');
-            } catch (Exception e) {
-                System.debug('LicenseShuffleBatch: Error updating users: ' + e.getMessage());
-                // Continue processing - log error but don't fail entire batch
-            }
-        }
-        
-        // Note: We don't insert change logs here because of MIXED_DML_OPERATION error.
-        // We accumulate logs and insert them via Queueable in finish() method.
-        if (!changeLogs.isEmpty()) {
-            System.debug('LicenseShuffleBatch: Accumulated ' + changeLogs.size() + ' change log records in this chunk');
-            for (License_Change_Log__c log : changeLogs) {
-                System.debug('  - Log for User: ' + log.User__c + ', Change: ' + log.Old_License__c + ' -> ' + log.New_License__c + ', Reason: ' + log.Reason__c);
-            }
-        } else {
-            System.debug('LicenseShuffleBatch: No change logs to accumulate in this chunk');
-        }
-    }
-    
-    /**
-     * Batch finish method - logs summary statistics
-     */
-    public void finish(Database.BatchableContext bc) {
-        try {
-            AsyncApexJob job = [
-                SELECT Status, NumberOfErrors, JobItemsProcessed,
-                    TotalJobItems, CreatedBy.Email
-                FROM AsyncApexJob
-                WHERE Id = :bc.getJobId()
-            ];
-            
-            System.debug('LicenseShuffleBatch: Batch job completed');
-            System.debug('Status: ' + job.Status);
-            System.debug('Job items processed: ' + job.JobItemsProcessed + '/' + job.TotalJobItems);
-            System.debug('Number of errors: ' + job.NumberOfErrors);
-        } catch (QueryException e) {
-            // Job may not exist in test context - that's okay
-            System.debug('LicenseShuffleBatch: Could not query job status: ' + e.getMessage());
-        }
-        
-        System.debug('Total users processed: ' + totalUsersProcessed);
-        System.debug('Total license changes: ' + totalChanges);
-        System.debug('Protected users: ' + protectedUserIds.size());
-        System.debug('Total change logs accumulated: ' + changeLogs.size());
-        
-        // Insert all accumulated change logs via Queueable to avoid MIXED_DML_OPERATION error
-        // This runs in a separate transaction after User updates are complete
-        if (!changeLogs.isEmpty()) {
-            try {
-                System.debug('LicenseShuffleBatch: Enqueueing LicenseChangeLogQueueable to insert ' + changeLogs.size() + ' change log records');
-                // Create a copy of the list to pass to Queueable (since it will be cleared)
-                List<License_Change_Log__c> logsToInsert = new List<License_Change_Log__c>(changeLogs);
-                LicenseChangeLogQueueable queueable = new LicenseChangeLogQueueable(logsToInsert);
-                
-                // In test context, execute directly instead of enqueuing to improve coverage
-                if (Test.isRunningTest()) {
-                    QueueableContext ctx = new TestQueueableContext();
-                    queueable.execute(ctx);
-                    System.debug('LicenseShuffleBatch: Test context - executed LicenseChangeLogQueueable directly');
-                } else {
-                    System.enqueueJob(queueable);
-                    System.debug('LicenseShuffleBatch: Successfully enqueued LicenseChangeLogQueueable job');
-                }
-            } catch (Exception e) {
-                System.debug('LicenseShuffleBatch: Error enqueueing LicenseChangeLogQueueable: ' + e.getMessage());
-                System.debug('LicenseShuffleBatch: Stack trace: ' + e.getStackTraceString());
-                // Log each failed record for debugging
-                for (License_Change_Log__c log : changeLogs) {
-                    System.debug('  - Failed to queue log: User=' + log.User__c + ', Old=' + log.Old_License__c + ', New=' + log.New_License__c);
-                }
-            }
-        } else {
-            System.debug('LicenseShuffleBatch: No change logs to insert');
-        }
-    }
-    
-    /**
-     * Test helper class for QueueableContext
-     */
-    private class TestQueueableContext implements QueueableContext {
-        public Id getJobId() {
-            return UserInfo.getUserId();
-        }
-    }
-    
-    /**
-     * Helper method to check if user is new (<90 days old)
-     */
-    private Boolean isNewUser(DateTime createdDate) {
-        if (createdDate == null) {
-            return false;
-        }
-        Integer daysSinceCreation = createdDate.date().daysBetween(Date.today());
-        return daysSinceCreation < NEW_USER_DAYS;
-    }
-    
-    /**
-     * Helper method to count user logins
-     * Uses fiscal year (Feb 1 - Jan 31) logic:
-     * - Feb, Mar, Apr (first 3 months of FY): Use last 365 days
-     * - May-Dec: Use current fiscal year (Feb 1 of current year)
-     * - Jan: Use fiscal year (Feb 1 of previous year)
-     */
-    private Integer countUserLogins(Id userId) {
-        Integer currentMonth = Date.today().month();
-        Date startDate;
-        Integer currentYear = Date.today().year();
-        
-        if (currentMonth >= 2 && currentMonth <= 4) {
-            // February, March, April: Use last 365 days (first 3 months of fiscal year)
-            startDate = Date.today().addDays(-365);
-        } else if (currentMonth >= 5) {
-            // May through December: Use current fiscal year (Feb 1 of current year)
-            startDate = Date.newInstance(currentYear, 2, 1);
-        } else {
-            // January: Use fiscal year (Feb 1 of previous year)
-            startDate = Date.newInstance(currentYear - 1, 2, 1);
-        }
-        
-        DateTime startDateTime = DateTime.newInstance(startDate, Time.newInstance(0, 0, 0, 0));
-        
-        // Query Fiscal_Year_Login_History__c for this user
-        Integer loginCount = [
-            SELECT COUNT()
-            FROM Fiscal_Year_Login_History__c
-            WHERE User__c = :userId
-            AND Login_Time__c >= :startDateTime
-        ];
-        
-        return loginCount;
-    }
-    
-    /**
-     * Helper method to calculate which users should have Premium licenses
-     * Returns set of User IDs that should have Premium licenses (max 475)
-     * Uses ALL users (both Premium and Login) collected across all chunks
-     * 
-     * Logic:
-     * 1. Always include protected users (Chairs and new users) - they must be Premium
-     * 2. Include all users with >5 logins
-     * 3. If total exceeds 475, sort all qualifying users by login count (descending) and take top 475
-     * 
-     * This ensures:
-     * - At most 475 Premium licenses are assigned
-     * - Protected users always get Premium
-     * - Users with >5 logins get Premium (up to the 475 limit)
-     * - If more than 475 qualify, top 475 by login count get Premium
-     */
-    private Set<Id> calculatePremiumUsersToKeep() {
-        Set<Id> usersToKeep = new Set<Id>();
-        
-        System.debug('LicenseShuffleBatch: Calculating which users should have Premium licenses');
-        System.debug('  Total users collected: ' + allUsers.size());
-        System.debug('  Protected user count: ' + protectedUserIds.size());
-        System.debug('  Max Premium licenses: ' + MAX_PREMIUM_LICENSES);
-        System.debug('  Login threshold: >' + LOGIN_THRESHOLD);
-        
-        // Step 1: Always include all protected users (they must be Premium)
-        Integer protectedCount = 0;
-        for (Id userId : protectedUserIds) {
-            if (allUsers.containsKey(userId)) {
-                usersToKeep.add(userId);
-                protectedCount++;
-                Integer loginCount = userLoginCounts.get(userId) != null ? userLoginCounts.get(userId) : 0;
-                System.debug('  Protected user (must be Premium): ' + userId + ' (login count: ' + loginCount + ')');
-            }
-        }
-        System.debug('  Protected users included: ' + protectedCount);
-        
-        // Step 2: Create list of qualifying users (non-protected users with >5 logins)
-        List<User> qualifyingUsers = new List<User>();
-        for (User u : allUsers.values()) {
-            if (!protectedUserIds.contains(u.Id)) {
-                Integer loginCount = userLoginCounts.get(u.Id) != null ? userLoginCounts.get(u.Id) : 0;
-                if (loginCount > LOGIN_THRESHOLD) {
-                    qualifyingUsers.add(u);
-                }
-            }
-        }
-        
-        System.debug('  Qualifying users (>' + LOGIN_THRESHOLD + ' logins): ' + qualifyingUsers.size());
-        
-        // Step 3: Sort qualifying users by login count (descending)
-        qualifyingUsers.sort(new UserLoginCountComparator(userLoginCounts));
-        
-        // Step 4: Select top users up to max (475 total)
-        Integer remainingSlots = MAX_PREMIUM_LICENSES - usersToKeep.size();
-        Integer addedCount = 0;
-        Integer loginUsersAdded = 0;
-        Integer premiumUsersAdded = 0;
-        
-        for (User u : qualifyingUsers) {
-            if (remainingSlots <= 0) {
-                break; // We've reached our max of 475
-            }
-            
-            Integer loginCount = userLoginCounts.get(u.Id) != null ? userLoginCounts.get(u.Id) : 0;
-            String currentLicense = u.Profile.UserLicense.Name;
-            
-            // Add user to Premium keep list
-            usersToKeep.add(u.Id);
-            remainingSlots--;
-            addedCount++;
-            
-            if (currentLicense == LOGIN_LICENSE) {
-                loginUsersAdded++;
-                System.debug('  Adding Login user to Premium: ' + u.Id + ' (login count: ' + loginCount + ')');
-            } else {
-                premiumUsersAdded++;
-                System.debug('  Keeping Premium user: ' + u.Id + ' (login count: ' + loginCount + ')');
-            }
-        }
-        
-        System.debug('  Qualifying users added: ' + addedCount + ' (Login: ' + loginUsersAdded + ', Premium: ' + premiumUsersAdded + ')');
-        System.debug('  Total users to have Premium licenses: ' + usersToKeep.size());
-        
-        // Log users who will be downgraded (Premium users not in keep list)
-        Integer premiumUsersToDowngrade = 0;
-        Integer totalLoginCountToDowngrade = 0;
-        for (User u : allUsers.values()) {
-            if (u.Profile.UserLicense.Name == PREMIUM_LICENSE && 
-                !usersToKeep.contains(u.Id) && 
-                !protectedUserIds.contains(u.Id)) {
-                premiumUsersToDowngrade++;
-                Integer loginCount = userLoginCounts.get(u.Id) != null ? userLoginCounts.get(u.Id) : 0;
-                totalLoginCountToDowngrade += loginCount;
-            }
-        }
-        System.debug('  Premium users to downgrade: ' + premiumUsersToDowngrade + ' (total logins: ' + totalLoginCountToDowngrade + ')');
-        
-        // Log qualifying users who didn't make the cut (if any)
-        Integer qualifyingUsersExcluded = 0;
-        for (User u : qualifyingUsers) {
-            if (!usersToKeep.contains(u.Id)) {
-                qualifyingUsersExcluded++;
-            }
-        }
-        if (qualifyingUsersExcluded > 0) {
-            System.debug('  Qualifying users excluded (exceeded 475 limit): ' + qualifyingUsersExcluded);
-        }
-        
-        return usersToKeep;
-    }
-    
-    /**
-     * Helper method to get Profile ID by name
-     */
-    private Id getProfileId(String profileName) {
-        Profile p = [SELECT Id FROM Profile WHERE Name = :profileName LIMIT 1];
-        return p.Id;
-    }
-    
-    /**
-     * Helper method to create change log record
-     */
-    private void createChangeLog(User u, String oldLicense, String newLicense,
-                                 String oldProfile, String newProfile,
-                                 Integer loginCount, String reason) {
-        License_Change_Log__c log = new License_Change_Log__c(
-            User__c = u.Id,
-            Old_License__c = oldLicense,
-            New_License__c = newLicense,
-            Old_Profile__c = oldProfile,
-            New_Profile__c = newProfile,
-            Login_Count__c = loginCount,
-            Reason__c = reason,
-            Changed_At__c = DateTime.now(),
-            Batch_Job_Id__c = batchJobId
-        );
-        changeLogs.add(log);
-    }
-    
-    /**
-     * Comparator class to sort users by login count (descending)
-     */
-    private class UserLoginCountComparator implements Comparator<User> {
-        private Map<Id, Integer> loginCounts;
-        
-        public UserLoginCountComparator(Map<Id, Integer> loginCounts) {
-            this.loginCounts = loginCounts;
-        }
-        
-        public Integer compare(User u1, User u2) {
-            Integer count1 = loginCounts.get(u1.Id) != null ? loginCounts.get(u1.Id) : 0;
-            Integer count2 = loginCounts.get(u2.Id) != null ? loginCounts.get(u2.Id) : 0;
-            
-            // Sort descending (highest login count first)
-            if (count1 > count2) {
-                return -1;
-            } else if (count1 < count2) {
-                return 1;
-            }
-            return 0;
-        }
-    }
-}
+  private static final Integer MAX_PREMIUM_LICENSES = 475;
+  private static final Integer LOGIN_THRESHOLD = 5;
+  private static final Integer NEW_USER_DAYS = 90;
+  private static final String CHAIR_PROFILE = 'SM Community Plus Chair';
+  private static final String PREMIUM_PROFILE = 'SM Community Plus Member';
+  private static final String LOGIN_PROFILE = 'SM Community Plus Login';
+  private static final String PREMIUM_LICENSE = 'Customer Community Plus';
+  private static final String LOGIN_LICENSE = 'Customer Community Plus Login';
 
+  // Stateful: populated across all execute() chunks, consumed once in finish()
+  private Set<Id> protectedUserIds = new Set<Id>();
+  private Map<Id, Integer> userLoginCounts = new Map<Id, Integer>();
+  private Map<Id, User> allUsers = new Map<Id, User>();
+  private String batchJobId;
+  private DateTime fiscalYearStart; // computed once in start()
+
+  // -------------------------------------------------------------------------
+  // start() — compute fiscal year window, return query locator
+  // -------------------------------------------------------------------------
+  public Database.QueryLocator start(Database.BatchableContext bc) {
+    batchJobId = bc.getJobId();
+    System.debug('LicenseShuffleBatch: Starting batch job ' + batchJobId);
+
+    Integer currentMonth = Date.today().month();
+    Integer currentYear = Date.today().year();
+    Date startDate;
+    if (currentMonth >= 2 && currentMonth <= 4) {
+      // Feb–Apr: first three months of fiscal year — use rolling 365 days
+      startDate = Date.today().addDays(-365);
+    } else if (currentMonth >= 5) {
+      // May–Dec: current fiscal year begins Feb 1 of this year
+      startDate = Date.newInstance(currentYear, 2, 1);
+    } else {
+      // Jan: fiscal year began Feb 1 of previous year
+      startDate = Date.newInstance(currentYear - 1, 2, 1);
+    }
+    fiscalYearStart = DateTime.newInstance(
+      startDate,
+      Time.newInstance(0, 0, 0, 0)
+    );
+    System.debug('LicenseShuffleBatch: Fiscal year start: ' + startDate);
+
+    return Database.getQueryLocator(
+      [
+        SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+        FROM User
+        WHERE
+          IsActive = TRUE
+          AND Profile.UserLicense.Name IN (:PREMIUM_LICENSE, :LOGIN_LICENSE)
+        ORDER BY Profile.UserLicense.Name, CreatedDate DESC
+      ]
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // execute() — COLLECTION ONLY. No DML, no decisions.
+  // -------------------------------------------------------------------------
+  public void execute(Database.BatchableContext bc, List<sObject> scope) {
+    if (scope == null || scope.isEmpty())
+      return;
+
+    Set<Id> chunkUserIds = new Set<Id>();
+    for (sObject obj : scope) {
+      User u = (User) obj;
+      allUsers.put(u.Id, u);
+      chunkUserIds.add(u.Id);
+      if (u.Profile.Name == CHAIR_PROFILE || isNewUser(u.CreatedDate)) {
+        protectedUserIds.add(u.Id);
+      }
+    }
+
+    // One aggregate SOQL for the whole chunk — replaces the previous per-user COUNT() loop
+    for (AggregateResult ar : [
+      SELECT User__c uid, COUNT(Id) cnt
+      FROM Fiscal_Year_Login_History__c
+      WHERE User__c IN :chunkUserIds AND Login_Time__c >= :fiscalYearStart
+      GROUP BY User__c
+    ]) {
+      userLoginCounts.put((Id) ar.get('uid'), (Integer) ar.get('cnt'));
+    }
+    // Users absent from results have 0 logins; map miss is handled as 0 in finish()
+  }
+
+  // -------------------------------------------------------------------------
+  // finish() — ACTION PHASE. Full picture of all users available here.
+  // -------------------------------------------------------------------------
+  public void finish(Database.BatchableContext bc) {
+    try {
+      AsyncApexJob job = [
+        SELECT Status, NumberOfErrors, JobItemsProcessed, TotalJobItems
+        FROM AsyncApexJob
+        WHERE Id = :bc.getJobId()
+      ];
+      System.debug(
+        'LicenseShuffleBatch: Completed — Status=' +
+          job.Status +
+          ' Items=' +
+          job.JobItemsProcessed +
+          '/' +
+          job.TotalJobItems +
+          ' Errors=' +
+          job.NumberOfErrors
+      );
+    } catch (QueryException e) {
+      System.debug(
+        'LicenseShuffleBatch: Could not query job status: ' + e.getMessage()
+      );
+    }
+
+    System.debug(
+      'LicenseShuffleBatch: Total users collected: ' + allUsers.size()
+    );
+    System.debug(
+      'LicenseShuffleBatch: Protected users: ' + protectedUserIds.size()
+    );
+
+    if (allUsers.isEmpty()) {
+      System.debug('LicenseShuffleBatch: No users to process');
+      return;
+    }
+
+    // Cache profile IDs — two SOQL queries total for this method
+    Map<String, Id> profileIds = new Map<String, Id>();
+    for (Profile p : [
+      SELECT Id, Name
+      FROM Profile
+      WHERE Name IN (:PREMIUM_PROFILE, :LOGIN_PROFILE)
+    ]) {
+      profileIds.put(p.Name, p.Id);
+    }
+
+    Set<Id> premiumUsersToKeep = calculatePremiumUsersToKeep();
+
+    List<User> usersToUpdate = new List<User>();
+    List<License_Change_Log__c> changeLogs = new List<License_Change_Log__c>();
+
+    for (User u : allUsers.values()) {
+      if (protectedUserIds.contains(u.Id))
+        continue;
+
+      String currentLicense = u.Profile.UserLicense.Name;
+      Integer loginCount = userLoginCounts.containsKey(u.Id)
+        ? userLoginCounts.get(u.Id)
+        : 0;
+
+      if (
+        currentLicense == PREMIUM_LICENSE && !premiumUsersToKeep.contains(u.Id)
+      ) {
+        usersToUpdate.add(
+          new User(Id = u.Id, ProfileId = profileIds.get(LOGIN_PROFILE))
+        );
+        changeLogs.add(
+          makeLog(
+            u,
+            PREMIUM_LICENSE,
+            LOGIN_LICENSE,
+            u.Profile.Name,
+            LOGIN_PROFILE,
+            loginCount,
+            'Low usage'
+          )
+        );
+      } else if (
+        currentLicense == LOGIN_LICENSE && premiumUsersToKeep.contains(u.Id)
+      ) {
+        usersToUpdate.add(
+          new User(Id = u.Id, ProfileId = profileIds.get(PREMIUM_PROFILE))
+        );
+        changeLogs.add(
+          makeLog(
+            u,
+            LOGIN_LICENSE,
+            PREMIUM_LICENSE,
+            u.Profile.Name,
+            PREMIUM_PROFILE,
+            loginCount,
+            'High usage'
+          )
+        );
+      }
+    }
+
+    System.debug(
+      'LicenseShuffleBatch: License changes planned: ' + usersToUpdate.size()
+    );
+
+    if (!usersToUpdate.isEmpty()) {
+      try {
+        update usersToUpdate;
+        System.debug(
+          'LicenseShuffleBatch: Updated ' + usersToUpdate.size() + ' users'
+        );
+      } catch (Exception e) {
+        System.debug(
+          'LicenseShuffleBatch: Error updating users: ' + e.getMessage()
+        );
+      }
+    }
+
+    if (!changeLogs.isEmpty()) {
+      try {
+        LicenseChangeLogQueueable q = new LicenseChangeLogQueueable(changeLogs);
+        if (Test.isRunningTest()) {
+          q.execute(new TestQueueableContext());
+        } else {
+          System.enqueueJob(q);
+        }
+        System.debug(
+          'LicenseShuffleBatch: Change logs enqueued: ' + changeLogs.size()
+        );
+      } catch (Exception e) {
+        System.debug(
+          'LicenseShuffleBatch: Error enqueueing change logs: ' + e.getMessage()
+        );
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private Boolean isNewUser(DateTime createdDate) {
+    if (createdDate == null)
+      return false;
+    return createdDate.date().daysBetween(Date.today()) < NEW_USER_DAYS;
+  }
+
+  /**
+   * Determine which users should hold Premium licenses (max 475).
+   *
+   * 1. Always include all protected users (Chairs and new users).
+   * 2. Add non-protected users with >5 logins, sorted descending by login count.
+   * 3. Stop when 475 slots are filled.
+   */
+  private Set<Id> calculatePremiumUsersToKeep() {
+    // Start with protected users that actually appear in our user set
+    Set<Id> usersToKeep = new Set<Id>();
+    for (Id uid : protectedUserIds) {
+      if (allUsers.containsKey(uid))
+        usersToKeep.add(uid);
+    }
+
+    // Collect non-protected users who qualify (>5 logins)
+    List<User> qualifying = new List<User>();
+    for (User u : allUsers.values()) {
+      if (!protectedUserIds.contains(u.Id)) {
+        Integer cnt = userLoginCounts.containsKey(u.Id)
+          ? userLoginCounts.get(u.Id)
+          : 0;
+        if (cnt > LOGIN_THRESHOLD)
+          qualifying.add(u);
+      }
+    }
+
+    // Sort descending by login count so highest-usage users get slots first
+    qualifying.sort(new UserLoginCountComparator(userLoginCounts));
+
+    Integer remaining = MAX_PREMIUM_LICENSES - usersToKeep.size();
+    for (User u : qualifying) {
+      if (remaining <= 0)
+        break;
+      usersToKeep.add(u.Id);
+      remaining--;
+    }
+
+    System.debug(
+      'LicenseShuffleBatch: Keep list — total: ' +
+        usersToKeep.size() +
+        ' protected: ' +
+        protectedUserIds.size() +
+        ' qualifying: ' +
+        qualifying.size()
+    );
+    return usersToKeep;
+  }
+
+  private License_Change_Log__c makeLog(
+    User u,
+    String oldLic,
+    String newLic,
+    String oldProf,
+    String newProf,
+    Integer cnt,
+    String reason
+  ) {
+    return new License_Change_Log__c(
+      User__c = u.Id,
+      Old_License__c = oldLic,
+      New_License__c = newLic,
+      Old_Profile__c = oldProf,
+      New_Profile__c = newProf,
+      Login_Count__c = cnt,
+      Reason__c = reason,
+      Changed_At__c = DateTime.now(),
+      Batch_Job_Id__c = batchJobId
+    );
+  }
+
+  private class TestQueueableContext implements QueueableContext {
+    public Id getJobId() {
+      return UserInfo.getUserId();
+    }
+  }
+
+  private class UserLoginCountComparator implements Comparator<User> {
+    private Map<Id, Integer> counts;
+    UserLoginCountComparator(Map<Id, Integer> counts) {
+      this.counts = counts;
+    }
+    public Integer compare(User a, User b) {
+      Integer ca = counts.containsKey(a.Id) ? counts.get(a.Id) : 0;
+      Integer cb = counts.containsKey(b.Id) ? counts.get(b.Id) : 0;
+      return ca > cb ? -1 : (ca < cb ? 1 : 0);
+    }
+  }
+}

--- a/force-app/main/default/classes/LicenseShuffleBatchTest.cls
+++ b/force-app/main/default/classes/LicenseShuffleBatchTest.cls
@@ -1,1600 +1,1697 @@
 /**
  * Test class for LicenseShuffleBatch
- * 
+ *
  * Tests the license shuffling batch job that optimizes Premium license usage.
  */
 @isTest
 private class LicenseShuffleBatchTest {
-    
-    @isTest
-    static void testBatchStartMethod() {
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        Database.QueryLocator ql = batch.start(bc);
-        Test.stopTest();
-        
-        System.assertNotEquals(null, ql, 'Query locator should not be null');
-        String queryString = ql.getQuery();
-        System.assert(queryString.contains('User'), 'Query should include User');
+  @isTest
+  static void testBatchStartMethod() {
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+    Database.QueryLocator ql = batch.start(bc);
+    Test.stopTest();
+
+    System.assertNotEquals(null, ql, 'Query locator should not be null');
+    String queryString = ql.getQuery();
+    System.assert(queryString.contains('User'), 'Query should include User');
+  }
+
+  @isTest
+  static void testBatchExecuteWithEmptyScope() {
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+    batch.execute(bc, new List<sObject>());
+    Test.stopTest();
+
+    System.assert(true, 'Batch handled empty scope gracefully');
+  }
+
+  @isTest
+  static void testBatchExecuteWithNullScope() {
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+    batch.execute(bc, null);
+    Test.stopTest();
+
+    System.assert(true, 'Batch handled null scope gracefully');
+  }
+
+  @isTest
+  static void testBatchFinishMethod() {
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    try {
+      batch.finish(bc);
+      System.assert(true, 'Finish method executed');
+    } catch (Exception e) {
+      // Expected if job doesn't exist in test context
+      System.assert(true, 'Finish method structure is valid');
     }
-    
-    @isTest
-    static void testBatchExecuteWithEmptyScope() {
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        batch.execute(bc, new List<sObject>());
-        Test.stopTest();
-        
-        System.assert(true, 'Batch handled empty scope gracefully');
+    Test.stopTest();
+  }
+
+  @isTest
+  static void testBatchStatefulTracking() {
+    // Test that stateful variables are tracked across execute calls
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    // Execute multiple times
+    batch.execute(bc, new List<sObject>());
+    batch.execute(bc, new List<sObject>());
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Stateful tracking works');
+  }
+
+  @isTest
+  static void testBatchWithUsers() {
+    // Get existing Community users if available
+    List<User> communityUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name IN (
+          'Customer Community Plus',
+          'Customer Community Plus Login'
+        )
+      LIMIT 10
+    ];
+
+    if (communityUsers.isEmpty()) {
+      // Skip test if no Community users available
+      return;
     }
-    
-    @isTest
-    static void testBatchExecuteWithNullScope() {
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        batch.execute(bc, null);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch handled null scope gracefully');
+
+    // Create Fiscal_Year_Login_History__c records for testing login counts
+    // Note: Login_History_Id__c has max length of 18 and must be unique
+    List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
+    Integer recordCounter = 0;
+    for (Integer i = 0; i < communityUsers.size() && i < 5; i++) {
+      User u = communityUsers[i];
+      for (Integer j = 0; j < 10; j++) {
+        // Use unique IDs (18 chars max, unique per record)
+        String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
+        Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+          Login_History_Id__c = uniqueId,
+          User__c = u.Id,
+          Login_Time__c = DateTime.now().addDays(-j)
+        );
+        loginHistoryRecords.add(record);
+      }
     }
-    
-    @isTest
-    static void testBatchFinishMethod() {
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        try {
-            batch.finish(bc);
-            System.assert(true, 'Finish method executed');
-        } catch (Exception e) {
-            // Expected if job doesn't exist in test context
-            System.assert(true, 'Finish method structure is valid');
-        }
-        Test.stopTest();
+
+    if (!loginHistoryRecords.isEmpty()) {
+      insert loginHistoryRecords;
     }
-    
-    @isTest
-    static void testBatchStatefulTracking() {
-        // Test that stateful variables are tracked across execute calls
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Execute multiple times
-        batch.execute(bc, new List<sObject>());
-        batch.execute(bc, new List<sObject>());
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Stateful tracking works');
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    // Convert users to sObject list
+    List<sObject> scope = new List<sObject>();
+    for (User u : communityUsers) {
+      scope.add((sObject) u);
     }
-    
-    @isTest
-    static void testBatchWithUsers() {
-        // Get existing Community users if available
-        List<User> communityUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-            LIMIT 10
-        ];
-        
-        if (communityUsers.isEmpty()) {
-            // Skip test if no Community users available
-            return;
-        }
-        
-        // Create Fiscal_Year_Login_History__c records for testing login counts
-        // Note: Login_History_Id__c has max length of 18 and must be unique
-        List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
-        Integer recordCounter = 0;
-        for (Integer i = 0; i < communityUsers.size() && i < 5; i++) {
-            User u = communityUsers[i];
-            for (Integer j = 0; j < 10; j++) {
-                // Use unique IDs (18 chars max, unique per record)
-                String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
-                Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                    Login_History_Id__c = uniqueId,
-                    User__c = u.Id,
-                    Login_Time__c = DateTime.now().addDays(-j)
-                );
-                loginHistoryRecords.add(record);
-            }
-        }
-        
-        if (!loginHistoryRecords.isEmpty()) {
-            insert loginHistoryRecords;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Convert users to sObject list
-        List<sObject> scope = new List<sObject>();
-        for (User u : communityUsers) {
-            scope.add((sObject)u);
-        }
-        
+
+    batch.execute(bc, scope);
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed with users');
+  }
+
+  @isTest
+  static void testBatchMultipleExecuteCalls() {
+    // Test that batch can handle multiple execute calls (simulating multiple chunks)
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    // Simulate multiple chunks
+    for (Integer i = 0; i < 3; i++) {
+      batch.execute(bc, new List<sObject>());
+    }
+
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch handled multiple execute calls');
+  }
+
+  @isTest
+  static void testBatchFinishWithJobQuery() {
+    // Test finish method - it will try to query AsyncApexJob
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    try {
+      batch.finish(bc);
+      System.assert(true, 'Finish method executed');
+    } catch (Exception e) {
+      // Expected if job doesn't exist - that's okay in test context
+      System.assert(true, 'Finish method handled missing job gracefully');
+    }
+    Test.stopTest();
+  }
+
+  @isTest
+  static void testBatchWithFiscalYearLoginHistory() {
+    // Test batch with Fiscal_Year_Login_History__c records to exercise login counting
+    User testUser = getTestUser();
+    if (testUser == null) {
+      return;
+    }
+
+    // Create login history records for current fiscal year
+    List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
+    Integer currentYear = Date.today().year();
+    Integer currentMonth = Date.today().month();
+    Date fiscalYearStart;
+
+    // Determine fiscal year start based on current month (same logic as batch)
+    if (currentMonth >= 2 && currentMonth <= 4) {
+      // Feb-Apr: Use last 365 days
+      fiscalYearStart = Date.today().addDays(-365);
+    } else if (currentMonth >= 5) {
+      // May-Dec: Current fiscal year (Feb 1 of current year)
+      fiscalYearStart = Date.newInstance(currentYear, 2, 1);
+    } else {
+      // Jan: Previous fiscal year (Feb 1 of previous year)
+      fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
+    }
+
+    for (Integer i = 0; i < 10; i++) {
+      String uniqueId = String.valueOf(3000 + i).leftPad(18, '0');
+      Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+        Login_History_Id__c = uniqueId,
+        User__c = testUser.Id,
+        Login_Time__c = DateTime.newInstance(
+          fiscalYearStart.addDays(i),
+          Time.newInstance(0, 0, 0, 0)
+        )
+      );
+      loginHistoryRecords.add(record);
+    }
+
+    if (!loginHistoryRecords.isEmpty()) {
+      insert loginHistoryRecords;
+    }
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    // Get Community users if available
+    List<User> communityUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name IN (
+          'Customer Community Plus',
+          'Customer Community Plus Login'
+        )
+      LIMIT 5
+    ];
+
+    if (!communityUsers.isEmpty()) {
+      List<sObject> scope = new List<sObject>();
+      for (User u : communityUsers) {
+        scope.add((sObject) u);
+      }
+      batch.execute(bc, scope);
+      batch.finish(bc);
+    } else {
+      batch.execute(bc, new List<sObject>());
+      batch.finish(bc);
+    }
+
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed with fiscal year login history');
+  }
+
+  @isTest
+  static void testBatchStartMethodQueryDetails() {
+    // Test that start method returns query with expected fields
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+    Database.QueryLocator ql = batch.start(bc);
+    String queryString = ql.getQuery();
+    Test.stopTest();
+
+    // Verify query contains expected fields
+    System.assert(
+      queryString.contains('Profile.UserLicense.Name'),
+      'Query should include license type'
+    );
+    System.assert(
+      queryString.contains('CreatedDate'),
+      'Query should include CreatedDate'
+    );
+    System.assert(
+      queryString.contains('IsActive'),
+      'Query should include IsActive'
+    );
+  }
+
+  @isTest
+  static void testBatchWithChangeLogs() {
+    // Test batch with users that will generate change logs
+    User testUser = getTestUser();
+    if (testUser == null) {
+      return;
+    }
+
+    // Get Community users
+    List<User> communityUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name IN (
+          'Customer Community Plus',
+          'Customer Community Plus Login'
+        )
+      LIMIT 10
+    ];
+
+    if (communityUsers.isEmpty()) {
+      return;
+    }
+
+    // Create login history records to simulate different login counts
+    List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
+    Integer currentYear = Date.today().year();
+    Integer currentMonth = Date.today().month();
+    Date fiscalYearStart;
+
+    if (currentMonth >= 2 && currentMonth <= 4) {
+      fiscalYearStart = Date.today().addDays(-365);
+    } else if (currentMonth >= 5) {
+      fiscalYearStart = Date.newInstance(currentYear, 2, 1);
+    } else {
+      fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
+    }
+
+    // Create login history for first user (high login count - >5)
+    for (Integer i = 0; i < 20; i++) {
+      String uniqueId = String.valueOf(4000 + i).leftPad(18, '0');
+      Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+        Login_History_Id__c = uniqueId,
+        User__c = communityUsers[0].Id,
+        Login_Time__c = DateTime.newInstance(
+          fiscalYearStart.addDays(i),
+          Time.newInstance(0, 0, 0, 0)
+        )
+      );
+      loginHistoryRecords.add(record);
+    }
+
+    // Create login history for second user (low login count - <=5)
+    if (communityUsers.size() > 1) {
+      for (Integer i = 0; i < 3; i++) {
+        String uniqueId = String.valueOf(5000 + i).leftPad(18, '0');
+        Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+          Login_History_Id__c = uniqueId,
+          User__c = communityUsers[1].Id,
+          Login_Time__c = DateTime.newInstance(
+            fiscalYearStart.addDays(i),
+            Time.newInstance(0, 0, 0, 0)
+          )
+        );
+        loginHistoryRecords.add(record);
+      }
+    }
+
+    // Create login history for more users with varying counts to test sorting
+    for (
+      Integer userIdx = 2;
+      userIdx < communityUsers.size() &&
+      userIdx < 7;
+      userIdx++
+    ) {
+      Integer loginCount = 10 + (userIdx * 5); // Varying login counts
+      for (Integer i = 0; i < loginCount && i < 50; i++) {
+        String uniqueId = String.valueOf(6000 + (userIdx * 100) + i)
+          .leftPad(18, '0');
+        Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+          Login_History_Id__c = uniqueId,
+          User__c = communityUsers[userIdx].Id,
+          Login_Time__c = DateTime.newInstance(
+            fiscalYearStart.addDays(i),
+            Time.newInstance(0, 0, 0, 0)
+          )
+        );
+        loginHistoryRecords.add(record);
+      }
+    }
+
+    if (!loginHistoryRecords.isEmpty()) {
+      insert loginHistoryRecords;
+    }
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    // Convert users to scope
+    List<sObject> scope = new List<sObject>();
+    for (User u : communityUsers) {
+      scope.add((sObject) u);
+    }
+
+    batch.execute(bc, scope);
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed with users and change logs');
+  }
+
+  @isTest
+  static void testBatchFinishWithChangeLogs() {
+    // Test finish method with change logs to test Queueable execution
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    // Execute and finish to test the Queueable path
+    batch.execute(bc, new List<sObject>());
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch finish method executed with Queueable path');
+  }
+
+  @isTest
+  static void testBatchWithProtectedUsers() {
+    // Test batch with users that should be protected (chairs and new users)
+    // Get Community users
+    List<User> communityUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name IN (
+          'Customer Community Plus',
+          'Customer Community Plus Login'
+        )
+      LIMIT 5
+    ];
+
+    if (communityUsers.isEmpty()) {
+      return;
+    }
+
+    // Create login history for users
+    List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
+    Integer currentYear = Date.today().year();
+    Integer currentMonth = Date.today().month();
+    Date fiscalYearStart;
+
+    if (currentMonth >= 2 && currentMonth <= 4) {
+      fiscalYearStart = Date.today().addDays(-365);
+    } else if (currentMonth >= 5) {
+      fiscalYearStart = Date.newInstance(currentYear, 2, 1);
+    } else {
+      fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
+    }
+
+    // Create login history for first user (high count)
+    for (Integer i = 0; i < 15; i++) {
+      String uniqueId = String.valueOf(7000 + i).leftPad(18, '0');
+      Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+        Login_History_Id__c = uniqueId,
+        User__c = communityUsers[0].Id,
+        Login_Time__c = DateTime.newInstance(
+          fiscalYearStart.addDays(i),
+          Time.newInstance(0, 0, 0, 0)
+        )
+      );
+      loginHistoryRecords.add(record);
+    }
+
+    if (!loginHistoryRecords.isEmpty()) {
+      insert loginHistoryRecords;
+    }
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    // Convert users to scope
+    List<sObject> scope = new List<sObject>();
+    for (User u : communityUsers) {
+      scope.add((sObject) u);
+    }
+
+    batch.execute(bc, scope);
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed with protected users scenario');
+  }
+
+  @isTest
+  static void testBatchWithDifferentLicenseTypes() {
+    // Test batch with both Premium and Login license users
+    List<User> premiumUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name = 'Customer Community Plus'
+      LIMIT 3
+    ];
+
+    List<User> loginUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name = 'Customer Community Plus Login'
+      LIMIT 3
+    ];
+
+    if (premiumUsers.isEmpty() && loginUsers.isEmpty()) {
+      return;
+    }
+
+    // Create login history for users with varying counts
+    List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
+    Integer currentYear = Date.today().year();
+    Integer currentMonth = Date.today().month();
+    Date fiscalYearStart;
+
+    if (currentMonth >= 2 && currentMonth <= 4) {
+      fiscalYearStart = Date.today().addDays(-365);
+    } else if (currentMonth >= 5) {
+      fiscalYearStart = Date.newInstance(currentYear, 2, 1);
+    } else {
+      fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
+    }
+
+    // High login count for some users (>5)
+    Integer recordCounter = 8000;
+    for (Integer i = 0; i < premiumUsers.size() && i < 2; i++) {
+      for (Integer j = 0; j < 10; j++) {
+        String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
+        Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+          Login_History_Id__c = uniqueId,
+          User__c = premiumUsers[i].Id,
+          Login_Time__c = DateTime.newInstance(
+            fiscalYearStart.addDays(j),
+            Time.newInstance(0, 0, 0, 0)
+          )
+        );
+        loginHistoryRecords.add(record);
+      }
+    }
+
+    // Low login count for login users (<=5)
+    for (Integer i = 0; i < loginUsers.size() && i < 2; i++) {
+      for (Integer j = 0; j < 3; j++) {
+        String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
+        Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+          Login_History_Id__c = uniqueId,
+          User__c = loginUsers[i].Id,
+          Login_Time__c = DateTime.newInstance(
+            fiscalYearStart.addDays(j),
+            Time.newInstance(0, 0, 0, 0)
+          )
+        );
+        loginHistoryRecords.add(record);
+      }
+    }
+
+    if (!loginHistoryRecords.isEmpty()) {
+      insert loginHistoryRecords;
+    }
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    // Combine both types of users
+    List<sObject> scope = new List<sObject>();
+    for (User u : premiumUsers) {
+      scope.add((sObject) u);
+    }
+    for (User u : loginUsers) {
+      scope.add((sObject) u);
+    }
+
+    if (!scope.isEmpty()) {
+      batch.execute(bc, scope);
+      batch.finish(bc);
+    }
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed with different license types');
+  }
+
+  @isTest
+  static void testBatchErrorHandlingInUpdate() {
+    // Test error handling when user update fails
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    // Execute with empty scope - this will test the error handling path
+    // even if no actual errors occur
+    batch.execute(bc, new List<sObject>());
+    Test.stopTest();
+
+    System.assert(true, 'Batch error handling tested');
+  }
+
+  @isTest
+  static void testBatchCalculatePremiumUsersToKeep() {
+    // Test the calculatePremiumUsersToKeep logic with various scenarios
+    // Get Community users
+    List<User> communityUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name IN (
+          'Customer Community Plus',
+          'Customer Community Plus Login'
+        )
+      LIMIT 10
+    ];
+
+    if (communityUsers.isEmpty()) {
+      return;
+    }
+
+    // Create login history with varying counts to test sorting and selection
+    List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
+    Integer currentYear = Date.today().year();
+    Integer currentMonth = Date.today().month();
+    Date fiscalYearStart;
+
+    if (currentMonth >= 2 && currentMonth <= 4) {
+      fiscalYearStart = Date.today().addDays(-365);
+    } else if (currentMonth >= 5) {
+      fiscalYearStart = Date.newInstance(currentYear, 2, 1);
+    } else {
+      fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
+    }
+
+    // Create varying login counts: some >5, some <=5
+    Integer recordCounter = 9000;
+    for (
+      Integer userIdx = 0;
+      userIdx < communityUsers.size() &&
+      userIdx < 8;
+      userIdx++
+    ) {
+      Integer loginCount = userIdx < 4 ? 15 + (userIdx * 5) : 3; // First 4 have >5, rest have <=5
+      for (Integer i = 0; i < loginCount && i < 30; i++) {
+        String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
+        Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+          Login_History_Id__c = uniqueId,
+          User__c = communityUsers[userIdx].Id,
+          Login_Time__c = DateTime.newInstance(
+            fiscalYearStart.addDays(i),
+            Time.newInstance(0, 0, 0, 0)
+          )
+        );
+        loginHistoryRecords.add(record);
+      }
+    }
+
+    if (!loginHistoryRecords.isEmpty()) {
+      insert loginHistoryRecords;
+    }
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    // Convert users to scope
+    List<sObject> scope = new List<sObject>();
+    for (User u : communityUsers) {
+      scope.add((sObject) u);
+    }
+
+    batch.execute(bc, scope);
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed calculatePremiumUsersToKeep logic');
+  }
+
+  @isTest
+  static void testBatchWithMaxPremiumLimit() {
+    // Test scenario where more than 475 users qualify for Premium
+    // This tests the sorting and selection logic when limit is exceeded
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    // Execute multiple times to simulate many users
+    for (Integer i = 0; i < 5; i++) {
+      batch.execute(bc, new List<sObject>());
+    }
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch handled max premium limit scenario');
+  }
+
+  @isTest
+  static void testBatchFinishWithAsyncApexJobQuery() {
+    // Test finish method that queries AsyncApexJob
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    // Execute to set up state
+    batch.execute(bc, new List<sObject>());
+
+    // Finish will try to query AsyncApexJob
+    try {
+      batch.finish(bc);
+      System.assert(true, 'Finish method executed');
+    } catch (Exception e) {
+      // Expected if job doesn't exist in test context
+      System.assert(true, 'Finish method handled missing job');
+    }
+    Test.stopTest();
+  }
+
+  @isTest
+  static void testBatchWithNewUsers() {
+    // Test batch with users created <90 days ago (should be protected)
+    // Get Community users and check their CreatedDate
+    List<User> communityUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name IN (
+          'Customer Community Plus',
+          'Customer Community Plus Login'
+        )
+        AND CreatedDate >= LAST_N_DAYS:89
+      LIMIT 5
+    ];
+
+    if (communityUsers.isEmpty()) {
+      // If no new users, test with regular users
+      communityUsers = [
+        SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+        FROM User
+        WHERE
+          IsActive = TRUE
+          AND Profile.UserLicense.Name IN (
+            'Customer Community Plus',
+            'Customer Community Plus Login'
+          )
+        LIMIT 5
+      ];
+    }
+
+    if (communityUsers.isEmpty()) {
+      return;
+    }
+
+    // Create login history
+    List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
+    Integer currentYear = Date.today().year();
+    Integer currentMonth = Date.today().month();
+    Date fiscalYearStart;
+
+    if (currentMonth >= 2 && currentMonth <= 4) {
+      fiscalYearStart = Date.today().addDays(-365);
+    } else if (currentMonth >= 5) {
+      fiscalYearStart = Date.newInstance(currentYear, 2, 1);
+    } else {
+      fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
+    }
+
+    Integer recordCounter = 10000;
+    for (Integer userIdx = 0; userIdx < communityUsers.size(); userIdx++) {
+      for (Integer i = 0; i < 8; i++) {
+        String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
+        Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+          Login_History_Id__c = uniqueId,
+          User__c = communityUsers[userIdx].Id,
+          Login_Time__c = DateTime.newInstance(
+            fiscalYearStart.addDays(i),
+            Time.newInstance(0, 0, 0, 0)
+          )
+        );
+        loginHistoryRecords.add(record);
+      }
+    }
+
+    if (!loginHistoryRecords.isEmpty()) {
+      insert loginHistoryRecords;
+    }
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    List<sObject> scope = new List<sObject>();
+    for (User u : communityUsers) {
+      scope.add((sObject) u);
+    }
+
+    batch.execute(bc, scope);
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed with new users scenario');
+  }
+
+  @isTest
+  static void testBatchWithChairProfileUsers() {
+    // Test batch with users that have Chair profile (should be protected)
+    List<User> chairUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE IsActive = TRUE AND Profile.Name = 'SM Community Plus Chair'
+      LIMIT 3
+    ];
+
+    if (chairUsers.isEmpty()) {
+      // If no chair users, test with regular users
+      chairUsers = [
+        SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+        FROM User
+        WHERE
+          IsActive = TRUE
+          AND Profile.UserLicense.Name IN (
+            'Customer Community Plus',
+            'Customer Community Plus Login'
+          )
+        LIMIT 3
+      ];
+    }
+
+    if (chairUsers.isEmpty()) {
+      return;
+    }
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    List<sObject> scope = new List<sObject>();
+    for (User u : chairUsers) {
+      scope.add((sObject) u);
+    }
+
+    batch.execute(bc, scope);
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed with chair profile users');
+  }
+
+  @isTest
+  static void testBatchWithMixedScenarios() {
+    // Comprehensive test with mixed scenarios: protected, high login, low login users
+    List<User> allCommunityUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name IN (
+          'Customer Community Plus',
+          'Customer Community Plus Login'
+        )
+      LIMIT 15
+    ];
+
+    if (allCommunityUsers.isEmpty()) {
+      return;
+    }
+
+    // Create login history with varying counts
+    List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
+    Integer currentYear = Date.today().year();
+    Integer currentMonth = Date.today().month();
+    Date fiscalYearStart;
+
+    if (currentMonth >= 2 && currentMonth <= 4) {
+      fiscalYearStart = Date.today().addDays(-365);
+    } else if (currentMonth >= 5) {
+      fiscalYearStart = Date.newInstance(currentYear, 2, 1);
+    } else {
+      fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
+    }
+
+    Integer recordCounter = 11000;
+    for (Integer userIdx = 0; userIdx < allCommunityUsers.size(); userIdx++) {
+      // Vary login counts: some high (>5), some low (<=5)
+      Integer loginCount = userIdx < 6 ? 10 + (userIdx * 3) : 3;
+      for (Integer i = 0; i < loginCount && i < 25; i++) {
+        String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
+        Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+          Login_History_Id__c = uniqueId,
+          User__c = allCommunityUsers[userIdx].Id,
+          Login_Time__c = DateTime.newInstance(
+            fiscalYearStart.addDays(i),
+            Time.newInstance(0, 0, 0, 0)
+          )
+        );
+        loginHistoryRecords.add(record);
+      }
+    }
+
+    if (!loginHistoryRecords.isEmpty()) {
+      insert loginHistoryRecords;
+    }
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    // Execute in multiple chunks to test stateful tracking
+    Integer chunkSize = 5;
+    for (Integer i = 0; i < allCommunityUsers.size(); i += chunkSize) {
+      List<sObject> scope = new List<sObject>();
+      for (
+        Integer j = i;
+        j < Math.min(i + chunkSize, allCommunityUsers.size());
+        j++
+      ) {
+        scope.add((sObject) allCommunityUsers[j]);
+      }
+      if (!scope.isEmpty()) {
         batch.execute(bc, scope);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed with users');
+      }
     }
-    
-    @isTest
-    static void testBatchMultipleExecuteCalls() {
-        // Test that batch can handle multiple execute calls (simulating multiple chunks)
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Simulate multiple chunks
-        for (Integer i = 0; i < 3; i++) {
-            batch.execute(bc, new List<sObject>());
-        }
-        
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch handled multiple execute calls');
+
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed with mixed scenarios');
+  }
+
+  @isTest
+  static void testBatchWithExactLoginThreshold() {
+    // Test users with exactly 5 logins (should not qualify) and 6 logins (should qualify)
+    List<User> communityUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name IN (
+          'Customer Community Plus',
+          'Customer Community Plus Login'
+        )
+      LIMIT 4
+    ];
+
+    if (communityUsers.isEmpty()) {
+      return;
     }
-    
-    @isTest
-    static void testBatchFinishWithJobQuery() {
-        // Test finish method - it will try to query AsyncApexJob
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        try {
-            batch.finish(bc);
-            System.assert(true, 'Finish method executed');
-        } catch (Exception e) {
-            // Expected if job doesn't exist - that's okay in test context
-            System.assert(true, 'Finish method handled missing job gracefully');
-        }
-        Test.stopTest();
+
+    // Create login history: some with exactly 5, some with 6+
+    List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
+    Integer currentYear = Date.today().year();
+    Integer currentMonth = Date.today().month();
+    Date fiscalYearStart;
+
+    if (currentMonth >= 2 && currentMonth <= 4) {
+      fiscalYearStart = Date.today().addDays(-365);
+    } else if (currentMonth >= 5) {
+      fiscalYearStart = Date.newInstance(currentYear, 2, 1);
+    } else {
+      fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
     }
-    
-    @isTest
-    static void testBatchWithFiscalYearLoginHistory() {
-        // Test batch with Fiscal_Year_Login_History__c records to exercise login counting
-        User testUser = getTestUser();
-        if (testUser == null) {
-            return;
-        }
-        
-        // Create login history records for current fiscal year
-        List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
-        Integer currentYear = Date.today().year();
-        Integer currentMonth = Date.today().month();
-        Date fiscalYearStart;
-        
-        // Determine fiscal year start based on current month (same logic as batch)
-        if (currentMonth >= 2 && currentMonth <= 4) {
-            // Feb-Apr: Use last 365 days
-            fiscalYearStart = Date.today().addDays(-365);
-        } else if (currentMonth >= 5) {
-            // May-Dec: Current fiscal year (Feb 1 of current year)
-            fiscalYearStart = Date.newInstance(currentYear, 2, 1);
-        } else {
-            // Jan: Previous fiscal year (Feb 1 of previous year)
-            fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
-        }
-        
-        for (Integer i = 0; i < 10; i++) {
-            String uniqueId = String.valueOf(3000 + i).leftPad(18, '0');
-            Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                Login_History_Id__c = uniqueId,
-                User__c = testUser.Id,
-                Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(i), Time.newInstance(0, 0, 0, 0))
-            );
-            loginHistoryRecords.add(record);
-        }
-        
-        if (!loginHistoryRecords.isEmpty()) {
-            insert loginHistoryRecords;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Get Community users if available
-        List<User> communityUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-            LIMIT 5
-        ];
-        
-        if (!communityUsers.isEmpty()) {
-            List<sObject> scope = new List<sObject>();
-            for (User u : communityUsers) {
-                scope.add((sObject)u);
-            }
-            batch.execute(bc, scope);
-            batch.finish(bc);
-        } else {
-            batch.execute(bc, new List<sObject>());
-            batch.finish(bc);
-        }
-        
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed with fiscal year login history');
+
+    Integer recordCounter = 12000;
+    for (Integer userIdx = 0; userIdx < communityUsers.size(); userIdx++) {
+      // First user: exactly 5 logins (should NOT qualify)
+      // Second user: 6 logins (should qualify)
+      // Third user: 10 logins (should qualify)
+      // Fourth user: 3 logins (should NOT qualify)
+      Integer loginCount = userIdx == 0
+        ? 5
+        : (userIdx == 1 ? 6 : (userIdx == 2 ? 10 : 3));
+
+      for (Integer i = 0; i < loginCount; i++) {
+        String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
+        Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+          Login_History_Id__c = uniqueId,
+          User__c = communityUsers[userIdx].Id,
+          Login_Time__c = DateTime.newInstance(
+            fiscalYearStart.addDays(i),
+            Time.newInstance(0, 0, 0, 0)
+          )
+        );
+        loginHistoryRecords.add(record);
+      }
     }
-    
-    @isTest
-    static void testBatchStartMethodQueryDetails() {
-        // Test that start method returns query with expected fields
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        Database.QueryLocator ql = batch.start(bc);
-        String queryString = ql.getQuery();
-        Test.stopTest();
-        
-        // Verify query contains expected fields
-        System.assert(queryString.contains('Profile.UserLicense.Name'), 'Query should include license type');
-        System.assert(queryString.contains('CreatedDate'), 'Query should include CreatedDate');
-        System.assert(queryString.contains('IsActive'), 'Query should include IsActive');
+
+    if (!loginHistoryRecords.isEmpty()) {
+      insert loginHistoryRecords;
     }
-    
-    @isTest
-    static void testBatchExecuteMultipleChunksWithRecalculation() {
-        // Test that batch handles multiple chunks and recalculation logic
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Execute multiple times to test stateful tracking and recalculation
-        batch.execute(bc, new List<sObject>());
-        batch.execute(bc, new List<sObject>());
-        batch.execute(bc, new List<sObject>());
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch handled multiple chunks with recalculation');
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    List<sObject> scope = new List<sObject>();
+    for (User u : communityUsers) {
+      scope.add((sObject) u);
     }
-    
-    @isTest
-    static void testBatchWithChangeLogs() {
-        // Test batch with users that will generate change logs
-        User testUser = getTestUser();
-        if (testUser == null) {
-            return;
-        }
-        
-        // Get Community users
-        List<User> communityUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-            LIMIT 10
-        ];
-        
-        if (communityUsers.isEmpty()) {
-            return;
-        }
-        
-        // Create login history records to simulate different login counts
-        List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
-        Integer currentYear = Date.today().year();
-        Integer currentMonth = Date.today().month();
-        Date fiscalYearStart;
-        
-        if (currentMonth >= 2 && currentMonth <= 4) {
-            fiscalYearStart = Date.today().addDays(-365);
-        } else if (currentMonth >= 5) {
-            fiscalYearStart = Date.newInstance(currentYear, 2, 1);
-        } else {
-            fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
-        }
-        
-        // Create login history for first user (high login count - >5)
-        for (Integer i = 0; i < 20; i++) {
-            String uniqueId = String.valueOf(4000 + i).leftPad(18, '0');
-            Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                Login_History_Id__c = uniqueId,
-                User__c = communityUsers[0].Id,
-                Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(i), Time.newInstance(0, 0, 0, 0))
-            );
-            loginHistoryRecords.add(record);
-        }
-        
-        // Create login history for second user (low login count - <=5)
-        if (communityUsers.size() > 1) {
-            for (Integer i = 0; i < 3; i++) {
-                String uniqueId = String.valueOf(5000 + i).leftPad(18, '0');
-                Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                    Login_History_Id__c = uniqueId,
-                    User__c = communityUsers[1].Id,
-                    Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(i), Time.newInstance(0, 0, 0, 0))
-                );
-                loginHistoryRecords.add(record);
-            }
-        }
-        
-        // Create login history for more users with varying counts to test sorting
-        for (Integer userIdx = 2; userIdx < communityUsers.size() && userIdx < 7; userIdx++) {
-            Integer loginCount = 10 + (userIdx * 5); // Varying login counts
-            for (Integer i = 0; i < loginCount && i < 50; i++) {
-                String uniqueId = String.valueOf(6000 + (userIdx * 100) + i).leftPad(18, '0');
-                Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                    Login_History_Id__c = uniqueId,
-                    User__c = communityUsers[userIdx].Id,
-                    Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(i), Time.newInstance(0, 0, 0, 0))
-                );
-                loginHistoryRecords.add(record);
-            }
-        }
-        
-        if (!loginHistoryRecords.isEmpty()) {
-            insert loginHistoryRecords;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Convert users to scope
-        List<sObject> scope = new List<sObject>();
-        for (User u : communityUsers) {
-            scope.add((sObject)u);
-        }
-        
-        batch.execute(bc, scope);
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed with users and change logs');
+
+    batch.execute(bc, scope);
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed with exact login threshold scenarios');
+  }
+
+  @isTest
+  static void testBatchIsNewUserNullCheck() {
+    // Test isNewUser method with null CreatedDate
+    // This tests the null check in isNewUser method
+    List<User> communityUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name IN (
+          'Customer Community Plus',
+          'Customer Community Plus Login'
+        )
+      LIMIT 3
+    ];
+
+    if (communityUsers.isEmpty()) {
+      return;
     }
-    
-    @isTest
-    static void testBatchFinishWithChangeLogs() {
-        // Test finish method with change logs to test Queueable execution
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Execute and finish to test the Queueable path
-        batch.execute(bc, new List<sObject>());
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch finish method executed with Queueable path');
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    List<sObject> scope = new List<sObject>();
+    for (User u : communityUsers) {
+      scope.add((sObject) u);
     }
-    
-    @isTest
-    static void testBatchWithRecalculationScenario() {
-        // Test the recalculation logic when significantly more users are discovered
-        // This tests the branch: allUsers.size() > premiumUsersToKeep.size() * 1.5
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Execute multiple times with empty scopes to simulate multiple chunks
-        // This will trigger the recalculation logic
-        batch.execute(bc, new List<sObject>());
-        batch.execute(bc, new List<sObject>());
-        batch.execute(bc, new List<sObject>());
-        batch.execute(bc, new List<sObject>());
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch handled recalculation scenario');
+
+    batch.execute(bc, scope);
+    Test.stopTest();
+
+    System.assert(
+      true,
+      'Batch handled users with CreatedDate (null check tested)'
+    );
+  }
+
+  @isTest
+  static void testBatchCountUserLoginsDifferentMonths() {
+    // Test countUserLogins method for different months
+    // This tests the fiscal year logic for Feb-Apr, May-Dec, and Jan
+    List<User> communityUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name IN (
+          'Customer Community Plus',
+          'Customer Community Plus Login'
+        )
+      LIMIT 3
+    ];
+
+    if (communityUsers.isEmpty()) {
+      return;
     }
-    
-    @isTest
-    static void testBatchWithProtectedUsers() {
-        // Test batch with users that should be protected (chairs and new users)
-        // Get Community users
-        List<User> communityUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-            LIMIT 5
-        ];
-        
-        if (communityUsers.isEmpty()) {
-            return;
-        }
-        
-        // Create login history for users
-        List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
-        Integer currentYear = Date.today().year();
-        Integer currentMonth = Date.today().month();
-        Date fiscalYearStart;
-        
-        if (currentMonth >= 2 && currentMonth <= 4) {
-            fiscalYearStart = Date.today().addDays(-365);
-        } else if (currentMonth >= 5) {
-            fiscalYearStart = Date.newInstance(currentYear, 2, 1);
-        } else {
-            fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
-        }
-        
-        // Create login history for first user (high count)
-        for (Integer i = 0; i < 15; i++) {
-            String uniqueId = String.valueOf(7000 + i).leftPad(18, '0');
-            Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                Login_History_Id__c = uniqueId,
-                User__c = communityUsers[0].Id,
-                Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(i), Time.newInstance(0, 0, 0, 0))
-            );
-            loginHistoryRecords.add(record);
-        }
-        
-        if (!loginHistoryRecords.isEmpty()) {
-            insert loginHistoryRecords;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Convert users to scope
-        List<sObject> scope = new List<sObject>();
-        for (User u : communityUsers) {
-            scope.add((sObject)u);
-        }
-        
-        batch.execute(bc, scope);
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed with protected users scenario');
+
+    // Create login history for different time periods to test all month branches
+    List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
+    Integer currentYear = Date.today().year();
+    Integer currentMonth = Date.today().month();
+
+    // Create records for last 365 days (covers Feb-Apr branch)
+    Date last365Days = Date.today().addDays(-365);
+    // Create records for current fiscal year (covers May-Dec branch)
+    Date currentFiscalYear = Date.newInstance(currentYear, 2, 1);
+    // Create records for previous fiscal year (covers Jan branch)
+    Date previousFiscalYear = Date.newInstance(currentYear - 1, 2, 1);
+
+    Integer recordCounter = 13000;
+
+    // Add records in different time periods
+    for (Integer i = 0; i < 5; i++) {
+      String uniqueId1 = String.valueOf(recordCounter++).leftPad(18, '0');
+      Fiscal_Year_Login_History__c record1 = new Fiscal_Year_Login_History__c(
+        Login_History_Id__c = uniqueId1,
+        User__c = communityUsers[0].Id,
+        Login_Time__c = DateTime.newInstance(
+          last365Days.addDays(i),
+          Time.newInstance(0, 0, 0, 0)
+        )
+      );
+      loginHistoryRecords.add(record1);
+
+      String uniqueId2 = String.valueOf(recordCounter++).leftPad(18, '0');
+      Fiscal_Year_Login_History__c record2 = new Fiscal_Year_Login_History__c(
+        Login_History_Id__c = uniqueId2,
+        User__c = communityUsers[0].Id,
+        Login_Time__c = DateTime.newInstance(
+          currentFiscalYear.addDays(i),
+          Time.newInstance(0, 0, 0, 0)
+        )
+      );
+      loginHistoryRecords.add(record2);
     }
-    
-    @isTest
-    static void testBatchWithDifferentLicenseTypes() {
-        // Test batch with both Premium and Login license users
-        List<User> premiumUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name = 'Customer Community Plus'
-            LIMIT 3
-        ];
-        
-        List<User> loginUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name = 'Customer Community Plus Login'
-            LIMIT 3
-        ];
-        
-        if (premiumUsers.isEmpty() && loginUsers.isEmpty()) {
-            return;
-        }
-        
-        // Create login history for users with varying counts
-        List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
-        Integer currentYear = Date.today().year();
-        Integer currentMonth = Date.today().month();
-        Date fiscalYearStart;
-        
-        if (currentMonth >= 2 && currentMonth <= 4) {
-            fiscalYearStart = Date.today().addDays(-365);
-        } else if (currentMonth >= 5) {
-            fiscalYearStart = Date.newInstance(currentYear, 2, 1);
-        } else {
-            fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
-        }
-        
-        // High login count for some users (>5)
-        Integer recordCounter = 8000;
-        for (Integer i = 0; i < premiumUsers.size() && i < 2; i++) {
-            for (Integer j = 0; j < 10; j++) {
-                String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
-                Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                    Login_History_Id__c = uniqueId,
-                    User__c = premiumUsers[i].Id,
-                    Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(j), Time.newInstance(0, 0, 0, 0))
-                );
-                loginHistoryRecords.add(record);
-            }
-        }
-        
-        // Low login count for login users (<=5)
-        for (Integer i = 0; i < loginUsers.size() && i < 2; i++) {
-            for (Integer j = 0; j < 3; j++) {
-                String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
-                Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                    Login_History_Id__c = uniqueId,
-                    User__c = loginUsers[i].Id,
-                    Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(j), Time.newInstance(0, 0, 0, 0))
-                );
-                loginHistoryRecords.add(record);
-            }
-        }
-        
-        if (!loginHistoryRecords.isEmpty()) {
-            insert loginHistoryRecords;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Combine both types of users
-        List<sObject> scope = new List<sObject>();
-        for (User u : premiumUsers) {
-            scope.add((sObject)u);
-        }
-        for (User u : loginUsers) {
-            scope.add((sObject)u);
-        }
-        
-        if (!scope.isEmpty()) {
-            batch.execute(bc, scope);
-            batch.finish(bc);
-        }
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed with different license types');
+
+    if (!loginHistoryRecords.isEmpty()) {
+      insert loginHistoryRecords;
     }
-    
-    @isTest
-    static void testBatchErrorHandlingInUpdate() {
-        // Test error handling when user update fails
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Execute with empty scope - this will test the error handling path
-        // even if no actual errors occur
-        batch.execute(bc, new List<sObject>());
-        Test.stopTest();
-        
-        System.assert(true, 'Batch error handling tested');
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    List<sObject> scope = new List<sObject>();
+    for (User u : communityUsers) {
+      scope.add((sObject) u);
     }
-    
-    @isTest
-    static void testBatchCalculatePremiumUsersToKeep() {
-        // Test the calculatePremiumUsersToKeep logic with various scenarios
-        // Get Community users
-        List<User> communityUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-            LIMIT 10
-        ];
-        
-        if (communityUsers.isEmpty()) {
-            return;
-        }
-        
-        // Create login history with varying counts to test sorting and selection
-        List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
-        Integer currentYear = Date.today().year();
-        Integer currentMonth = Date.today().month();
-        Date fiscalYearStart;
-        
-        if (currentMonth >= 2 && currentMonth <= 4) {
-            fiscalYearStart = Date.today().addDays(-365);
-        } else if (currentMonth >= 5) {
-            fiscalYearStart = Date.newInstance(currentYear, 2, 1);
-        } else {
-            fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
-        }
-        
-        // Create varying login counts: some >5, some <=5
-        Integer recordCounter = 9000;
-        for (Integer userIdx = 0; userIdx < communityUsers.size() && userIdx < 8; userIdx++) {
-            Integer loginCount = userIdx < 4 ? 15 + (userIdx * 5) : 3; // First 4 have >5, rest have <=5
-            for (Integer i = 0; i < loginCount && i < 30; i++) {
-                String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
-                Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                    Login_History_Id__c = uniqueId,
-                    User__c = communityUsers[userIdx].Id,
-                    Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(i), Time.newInstance(0, 0, 0, 0))
-                );
-                loginHistoryRecords.add(record);
-            }
-        }
-        
-        if (!loginHistoryRecords.isEmpty()) {
-            insert loginHistoryRecords;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Convert users to scope
-        List<sObject> scope = new List<sObject>();
-        for (User u : communityUsers) {
-            scope.add((sObject)u);
-        }
-        
-        batch.execute(bc, scope);
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed calculatePremiumUsersToKeep logic');
+
+    batch.execute(bc, scope);
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed countUserLogins for different months');
+  }
+
+  @isTest
+  static void testBatchSortingLogic() {
+    // Test the sorting logic in calculatePremiumUsersToKeep
+    // Create users with varying login counts to test the comparator
+    List<User> communityUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name IN (
+          'Customer Community Plus',
+          'Customer Community Plus Login'
+        )
+      LIMIT 8
+    ];
+
+    if (communityUsers.isEmpty()) {
+      return;
     }
-    
-    @isTest
-    static void testBatchWithMaxPremiumLimit() {
-        // Test scenario where more than 475 users qualify for Premium
-        // This tests the sorting and selection logic when limit is exceeded
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Execute multiple times to simulate many users
-        for (Integer i = 0; i < 5; i++) {
-            batch.execute(bc, new List<sObject>());
-        }
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch handled max premium limit scenario');
+
+    // Create login history with descending counts to test sorting
+    List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
+    Integer currentYear = Date.today().year();
+    Integer currentMonth = Date.today().month();
+    Date fiscalYearStart;
+
+    if (currentMonth >= 2 && currentMonth <= 4) {
+      fiscalYearStart = Date.today().addDays(-365);
+    } else if (currentMonth >= 5) {
+      fiscalYearStart = Date.newInstance(currentYear, 2, 1);
+    } else {
+      fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
     }
-    
-    @isTest
-    static void testBatchFinishWithAsyncApexJobQuery() {
-        // Test finish method that queries AsyncApexJob
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Execute to set up state
-        batch.execute(bc, new List<sObject>());
-        
-        // Finish will try to query AsyncApexJob
-        try {
-            batch.finish(bc);
-            System.assert(true, 'Finish method executed');
-        } catch (Exception e) {
-            // Expected if job doesn't exist in test context
-            System.assert(true, 'Finish method handled missing job');
-        }
-        Test.stopTest();
+
+    Integer recordCounter = 14000;
+    // Create varying login counts: 20, 15, 12, 10, 8, 7, 6, 4
+    Integer[] loginCounts = new List<Integer>{ 20, 15, 12, 10, 8, 7, 6, 4 };
+
+    for (
+      Integer userIdx = 0;
+      userIdx < communityUsers.size() &&
+      userIdx < loginCounts.size();
+      userIdx++
+    ) {
+      Integer loginCount = loginCounts[userIdx];
+      for (Integer i = 0; i < loginCount; i++) {
+        String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
+        Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+          Login_History_Id__c = uniqueId,
+          User__c = communityUsers[userIdx].Id,
+          Login_Time__c = DateTime.newInstance(
+            fiscalYearStart.addDays(i),
+            Time.newInstance(0, 0, 0, 0)
+          )
+        );
+        loginHistoryRecords.add(record);
+      }
     }
-    
-    @isTest
-    static void testBatchWithNewUsers() {
-        // Test batch with users created <90 days ago (should be protected)
-        // Get Community users and check their CreatedDate
-        List<User> communityUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-            AND CreatedDate >= LAST_N_DAYS:89
-            LIMIT 5
-        ];
-        
-        if (communityUsers.isEmpty()) {
-            // If no new users, test with regular users
-            communityUsers = [
-                SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-                FROM User
-                WHERE IsActive = true
-                AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-                LIMIT 5
-            ];
-        }
-        
-        if (communityUsers.isEmpty()) {
-            return;
-        }
-        
-        // Create login history
-        List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
-        Integer currentYear = Date.today().year();
-        Integer currentMonth = Date.today().month();
-        Date fiscalYearStart;
-        
-        if (currentMonth >= 2 && currentMonth <= 4) {
-            fiscalYearStart = Date.today().addDays(-365);
-        } else if (currentMonth >= 5) {
-            fiscalYearStart = Date.newInstance(currentYear, 2, 1);
-        } else {
-            fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
-        }
-        
-        Integer recordCounter = 10000;
-        for (Integer userIdx = 0; userIdx < communityUsers.size(); userIdx++) {
-            for (Integer i = 0; i < 8; i++) {
-                String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
-                Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                    Login_History_Id__c = uniqueId,
-                    User__c = communityUsers[userIdx].Id,
-                    Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(i), Time.newInstance(0, 0, 0, 0))
-                );
-                loginHistoryRecords.add(record);
-            }
-        }
-        
-        if (!loginHistoryRecords.isEmpty()) {
-            insert loginHistoryRecords;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        List<sObject> scope = new List<sObject>();
-        for (User u : communityUsers) {
-            scope.add((sObject)u);
-        }
-        
-        batch.execute(bc, scope);
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed with new users scenario');
+
+    if (!loginHistoryRecords.isEmpty()) {
+      insert loginHistoryRecords;
     }
-    
-    @isTest
-    static void testBatchWithChairProfileUsers() {
-        // Test batch with users that have Chair profile (should be protected)
-        List<User> chairUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.Name = 'SM Community Plus Chair'
-            LIMIT 3
-        ];
-        
-        if (chairUsers.isEmpty()) {
-            // If no chair users, test with regular users
-            chairUsers = [
-                SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-                FROM User
-                WHERE IsActive = true
-                AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-                LIMIT 3
-            ];
-        }
-        
-        if (chairUsers.isEmpty()) {
-            return;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        List<sObject> scope = new List<sObject>();
-        for (User u : chairUsers) {
-            scope.add((sObject)u);
-        }
-        
-        batch.execute(bc, scope);
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed with chair profile users');
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    List<sObject> scope = new List<sObject>();
+    for (User u : communityUsers) {
+      scope.add((sObject) u);
     }
-    
-    @isTest
-    static void testBatchWithMixedScenarios() {
-        // Comprehensive test with mixed scenarios: protected, high login, low login users
-        List<User> allCommunityUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-            LIMIT 15
-        ];
-        
-        if (allCommunityUsers.isEmpty()) {
-            return;
-        }
-        
-        // Create login history with varying counts
-        List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
-        Integer currentYear = Date.today().year();
-        Integer currentMonth = Date.today().month();
-        Date fiscalYearStart;
-        
-        if (currentMonth >= 2 && currentMonth <= 4) {
-            fiscalYearStart = Date.today().addDays(-365);
-        } else if (currentMonth >= 5) {
-            fiscalYearStart = Date.newInstance(currentYear, 2, 1);
-        } else {
-            fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
-        }
-        
-        Integer recordCounter = 11000;
-        for (Integer userIdx = 0; userIdx < allCommunityUsers.size(); userIdx++) {
-            // Vary login counts: some high (>5), some low (<=5)
-            Integer loginCount = userIdx < 6 ? 10 + (userIdx * 3) : 3;
-            for (Integer i = 0; i < loginCount && i < 25; i++) {
-                String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
-                Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                    Login_History_Id__c = uniqueId,
-                    User__c = allCommunityUsers[userIdx].Id,
-                    Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(i), Time.newInstance(0, 0, 0, 0))
-                );
-                loginHistoryRecords.add(record);
-            }
-        }
-        
-        if (!loginHistoryRecords.isEmpty()) {
-            insert loginHistoryRecords;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Execute in multiple chunks to test stateful tracking
-        Integer chunkSize = 5;
-        for (Integer i = 0; i < allCommunityUsers.size(); i += chunkSize) {
-            List<sObject> scope = new List<sObject>();
-            for (Integer j = i; j < Math.min(i + chunkSize, allCommunityUsers.size()); j++) {
-                scope.add((sObject)allCommunityUsers[j]);
-            }
-            if (!scope.isEmpty()) {
-                batch.execute(bc, scope);
-            }
-        }
-        
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed with mixed scenarios');
+
+    batch.execute(bc, scope);
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed sorting logic');
+  }
+
+  @isTest
+  static void testBatchWithMaxPremiumLimitExceeded() {
+    // Test scenario where more than 475 users qualify for Premium
+    // This tests the logic that selects top 475 by login count
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    // Execute with many empty scopes to simulate many users
+    // This will test the logic when premiumUsersToKeep approaches MAX_PREMIUM_LICENSES
+    for (Integer i = 0; i < 20; i++) {
+      batch.execute(bc, new List<sObject>());
     }
-    
-    @isTest
-    static void testBatchTargetCalculatedFlagLogic() {
-        // Test the targetCalculated flag logic - first calculation and recalculation
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // First execute - should trigger initial calculation (!targetCalculated)
-        batch.execute(bc, new List<sObject>());
-        
-        // Second execute - should test the else branch (targetCalculated is true)
-        batch.execute(bc, new List<sObject>());
-        
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch handled targetCalculated flag logic');
+
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch handled max premium limit exceeded scenario');
+  }
+
+  @isTest
+  static void testBatchPremiumUserDowngradePath() {
+    // Test the path where Premium users are downgraded (not in keep list)
+    List<User> premiumUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name = 'Customer Community Plus'
+        AND Profile.Name != 'SM Community Plus Chair'
+      LIMIT 3
+    ];
+
+    if (premiumUsers.isEmpty()) {
+      return;
     }
-    
-    @isTest
-    static void testBatchRecalculationBranch() {
-        // Test the recalculation branch: allUsers.size() > premiumUsersToKeep.size() * 1.5
-        // This requires simulating a scenario where we discover significantly more users
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Execute multiple times with empty scopes to build up allUsers map
-        // This simulates discovering more users across chunks
-        for (Integer i = 0; i < 10; i++) {
-            batch.execute(bc, new List<sObject>());
-        }
-        
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch handled recalculation branch');
+
+    // Create low login counts (<5) so they should be downgraded
+    List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
+    Integer currentYear = Date.today().year();
+    Integer currentMonth = Date.today().month();
+    Date fiscalYearStart;
+
+    if (currentMonth >= 2 && currentMonth <= 4) {
+      fiscalYearStart = Date.today().addDays(-365);
+    } else if (currentMonth >= 5) {
+      fiscalYearStart = Date.newInstance(currentYear, 2, 1);
+    } else {
+      fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
     }
-    
-    @isTest
-    static void testBatchWithExactLoginThreshold() {
-        // Test users with exactly 5 logins (should not qualify) and 6 logins (should qualify)
-        List<User> communityUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-            LIMIT 4
-        ];
-        
-        if (communityUsers.isEmpty()) {
-            return;
-        }
-        
-        // Create login history: some with exactly 5, some with 6+
-        List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
-        Integer currentYear = Date.today().year();
-        Integer currentMonth = Date.today().month();
-        Date fiscalYearStart;
-        
-        if (currentMonth >= 2 && currentMonth <= 4) {
-            fiscalYearStart = Date.today().addDays(-365);
-        } else if (currentMonth >= 5) {
-            fiscalYearStart = Date.newInstance(currentYear, 2, 1);
-        } else {
-            fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
-        }
-        
-        Integer recordCounter = 12000;
-        for (Integer userIdx = 0; userIdx < communityUsers.size(); userIdx++) {
-            // First user: exactly 5 logins (should NOT qualify)
-            // Second user: 6 logins (should qualify)
-            // Third user: 10 logins (should qualify)
-            // Fourth user: 3 logins (should NOT qualify)
-            Integer loginCount = userIdx == 0 ? 5 : (userIdx == 1 ? 6 : (userIdx == 2 ? 10 : 3));
-            
-            for (Integer i = 0; i < loginCount; i++) {
-                String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
-                Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                    Login_History_Id__c = uniqueId,
-                    User__c = communityUsers[userIdx].Id,
-                    Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(i), Time.newInstance(0, 0, 0, 0))
-                );
-                loginHistoryRecords.add(record);
-            }
-        }
-        
-        if (!loginHistoryRecords.isEmpty()) {
-            insert loginHistoryRecords;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        List<sObject> scope = new List<sObject>();
-        for (User u : communityUsers) {
-            scope.add((sObject)u);
-        }
-        
-        batch.execute(bc, scope);
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed with exact login threshold scenarios');
+
+    Integer recordCounter = 15000;
+    for (Integer userIdx = 0; userIdx < premiumUsers.size(); userIdx++) {
+      // Low login count (should be downgraded)
+      for (Integer i = 0; i < 3; i++) {
+        String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
+        Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+          Login_History_Id__c = uniqueId,
+          User__c = premiumUsers[userIdx].Id,
+          Login_Time__c = DateTime.newInstance(
+            fiscalYearStart.addDays(i),
+            Time.newInstance(0, 0, 0, 0)
+          )
+        );
+        loginHistoryRecords.add(record);
+      }
     }
-    
-    @isTest
-    static void testBatchIsNewUserNullCheck() {
-        // Test isNewUser method with null CreatedDate
-        // This tests the null check in isNewUser method
-        List<User> communityUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-            LIMIT 3
-        ];
-        
-        if (communityUsers.isEmpty()) {
-            return;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        List<sObject> scope = new List<sObject>();
-        for (User u : communityUsers) {
-            scope.add((sObject)u);
-        }
-        
-        batch.execute(bc, scope);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch handled users with CreatedDate (null check tested)');
+
+    if (!loginHistoryRecords.isEmpty()) {
+      insert loginHistoryRecords;
     }
-    
-    @isTest
-    static void testBatchCountUserLoginsDifferentMonths() {
-        // Test countUserLogins method for different months
-        // This tests the fiscal year logic for Feb-Apr, May-Dec, and Jan
-        List<User> communityUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-            LIMIT 3
-        ];
-        
-        if (communityUsers.isEmpty()) {
-            return;
-        }
-        
-        // Create login history for different time periods to test all month branches
-        List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
-        Integer currentYear = Date.today().year();
-        Integer currentMonth = Date.today().month();
-        
-        // Create records for last 365 days (covers Feb-Apr branch)
-        Date last365Days = Date.today().addDays(-365);
-        // Create records for current fiscal year (covers May-Dec branch)
-        Date currentFiscalYear = Date.newInstance(currentYear, 2, 1);
-        // Create records for previous fiscal year (covers Jan branch)
-        Date previousFiscalYear = Date.newInstance(currentYear - 1, 2, 1);
-        
-        Integer recordCounter = 13000;
-        
-        // Add records in different time periods
-        for (Integer i = 0; i < 5; i++) {
-            String uniqueId1 = String.valueOf(recordCounter++).leftPad(18, '0');
-            Fiscal_Year_Login_History__c record1 = new Fiscal_Year_Login_History__c(
-                Login_History_Id__c = uniqueId1,
-                User__c = communityUsers[0].Id,
-                Login_Time__c = DateTime.newInstance(last365Days.addDays(i), Time.newInstance(0, 0, 0, 0))
-            );
-            loginHistoryRecords.add(record1);
-            
-            String uniqueId2 = String.valueOf(recordCounter++).leftPad(18, '0');
-            Fiscal_Year_Login_History__c record2 = new Fiscal_Year_Login_History__c(
-                Login_History_Id__c = uniqueId2,
-                User__c = communityUsers[0].Id,
-                Login_Time__c = DateTime.newInstance(currentFiscalYear.addDays(i), Time.newInstance(0, 0, 0, 0))
-            );
-            loginHistoryRecords.add(record2);
-        }
-        
-        if (!loginHistoryRecords.isEmpty()) {
-            insert loginHistoryRecords;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        List<sObject> scope = new List<sObject>();
-        for (User u : communityUsers) {
-            scope.add((sObject)u);
-        }
-        
-        batch.execute(bc, scope);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed countUserLogins for different months');
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    List<sObject> scope = new List<sObject>();
+    for (User u : premiumUsers) {
+      scope.add((sObject) u);
     }
-    
-    @isTest
-    static void testBatchSortingLogic() {
-        // Test the sorting logic in calculatePremiumUsersToKeep
-        // Create users with varying login counts to test the comparator
-        List<User> communityUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-            LIMIT 8
-        ];
-        
-        if (communityUsers.isEmpty()) {
-            return;
-        }
-        
-        // Create login history with descending counts to test sorting
-        List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
-        Integer currentYear = Date.today().year();
-        Integer currentMonth = Date.today().month();
-        Date fiscalYearStart;
-        
-        if (currentMonth >= 2 && currentMonth <= 4) {
-            fiscalYearStart = Date.today().addDays(-365);
-        } else if (currentMonth >= 5) {
-            fiscalYearStart = Date.newInstance(currentYear, 2, 1);
-        } else {
-            fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
-        }
-        
-        Integer recordCounter = 14000;
-        // Create varying login counts: 20, 15, 12, 10, 8, 7, 6, 4
-        Integer[] loginCounts = new Integer[]{20, 15, 12, 10, 8, 7, 6, 4};
-        
-        for (Integer userIdx = 0; userIdx < communityUsers.size() && userIdx < loginCounts.size(); userIdx++) {
-            Integer loginCount = loginCounts[userIdx];
-            for (Integer i = 0; i < loginCount; i++) {
-                String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
-                Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                    Login_History_Id__c = uniqueId,
-                    User__c = communityUsers[userIdx].Id,
-                    Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(i), Time.newInstance(0, 0, 0, 0))
-                );
-                loginHistoryRecords.add(record);
-            }
-        }
-        
-        if (!loginHistoryRecords.isEmpty()) {
-            insert loginHistoryRecords;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        List<sObject> scope = new List<sObject>();
-        for (User u : communityUsers) {
-            scope.add((sObject)u);
-        }
-        
-        batch.execute(bc, scope);
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed sorting logic');
+
+    batch.execute(bc, scope);
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed premium user downgrade path');
+  }
+
+  @isTest
+  static void testBatchLoginUserUpgradePath() {
+    // Test the path where Login users are upgraded (in keep list with >5 logins)
+    List<User> loginUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name = 'Customer Community Plus Login'
+      LIMIT 3
+    ];
+
+    if (loginUsers.isEmpty()) {
+      return;
     }
-    
-    @isTest
-    static void testBatchWithMaxPremiumLimitExceeded() {
-        // Test scenario where more than 475 users qualify for Premium
-        // This tests the logic that selects top 475 by login count
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Execute with many empty scopes to simulate many users
-        // This will test the logic when premiumUsersToKeep approaches MAX_PREMIUM_LICENSES
-        for (Integer i = 0; i < 20; i++) {
-            batch.execute(bc, new List<sObject>());
-        }
-        
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch handled max premium limit exceeded scenario');
+
+    // Create high login counts (>5) so they should be upgraded
+    List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
+    Integer currentYear = Date.today().year();
+    Integer currentMonth = Date.today().month();
+    Date fiscalYearStart;
+
+    if (currentMonth >= 2 && currentMonth <= 4) {
+      fiscalYearStart = Date.today().addDays(-365);
+    } else if (currentMonth >= 5) {
+      fiscalYearStart = Date.newInstance(currentYear, 2, 1);
+    } else {
+      fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
     }
-    
-    @isTest
-    static void testBatchPremiumUserDowngradePath() {
-        // Test the path where Premium users are downgraded (not in keep list)
-        List<User> premiumUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name = 'Customer Community Plus'
-            AND Profile.Name != 'SM Community Plus Chair'
-            LIMIT 3
-        ];
-        
-        if (premiumUsers.isEmpty()) {
-            return;
-        }
-        
-        // Create low login counts (<5) so they should be downgraded
-        List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
-        Integer currentYear = Date.today().year();
-        Integer currentMonth = Date.today().month();
-        Date fiscalYearStart;
-        
-        if (currentMonth >= 2 && currentMonth <= 4) {
-            fiscalYearStart = Date.today().addDays(-365);
-        } else if (currentMonth >= 5) {
-            fiscalYearStart = Date.newInstance(currentYear, 2, 1);
-        } else {
-            fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
-        }
-        
-        Integer recordCounter = 15000;
-        for (Integer userIdx = 0; userIdx < premiumUsers.size(); userIdx++) {
-            // Low login count (should be downgraded)
-            for (Integer i = 0; i < 3; i++) {
-                String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
-                Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                    Login_History_Id__c = uniqueId,
-                    User__c = premiumUsers[userIdx].Id,
-                    Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(i), Time.newInstance(0, 0, 0, 0))
-                );
-                loginHistoryRecords.add(record);
-            }
-        }
-        
-        if (!loginHistoryRecords.isEmpty()) {
-            insert loginHistoryRecords;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        List<sObject> scope = new List<sObject>();
-        for (User u : premiumUsers) {
-            scope.add((sObject)u);
-        }
-        
-        batch.execute(bc, scope);
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed premium user downgrade path');
+
+    Integer recordCounter = 16000;
+    for (Integer userIdx = 0; userIdx < loginUsers.size(); userIdx++) {
+      // High login count (should be upgraded)
+      for (Integer i = 0; i < 15; i++) {
+        String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
+        Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+          Login_History_Id__c = uniqueId,
+          User__c = loginUsers[userIdx].Id,
+          Login_Time__c = DateTime.newInstance(
+            fiscalYearStart.addDays(i),
+            Time.newInstance(0, 0, 0, 0)
+          )
+        );
+        loginHistoryRecords.add(record);
+      }
     }
-    
-    @isTest
-    static void testBatchLoginUserUpgradePath() {
-        // Test the path where Login users are upgraded (in keep list with >5 logins)
-        List<User> loginUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name = 'Customer Community Plus Login'
-            LIMIT 3
-        ];
-        
-        if (loginUsers.isEmpty()) {
-            return;
-        }
-        
-        // Create high login counts (>5) so they should be upgraded
-        List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
-        Integer currentYear = Date.today().year();
-        Integer currentMonth = Date.today().month();
-        Date fiscalYearStart;
-        
-        if (currentMonth >= 2 && currentMonth <= 4) {
-            fiscalYearStart = Date.today().addDays(-365);
-        } else if (currentMonth >= 5) {
-            fiscalYearStart = Date.newInstance(currentYear, 2, 1);
-        } else {
-            fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
-        }
-        
-        Integer recordCounter = 16000;
-        for (Integer userIdx = 0; userIdx < loginUsers.size(); userIdx++) {
-            // High login count (should be upgraded)
-            for (Integer i = 0; i < 15; i++) {
-                String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
-                Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                    Login_History_Id__c = uniqueId,
-                    User__c = loginUsers[userIdx].Id,
-                    Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(i), Time.newInstance(0, 0, 0, 0))
-                );
-                loginHistoryRecords.add(record);
-            }
-        }
-        
-        if (!loginHistoryRecords.isEmpty()) {
-            insert loginHistoryRecords;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        List<sObject> scope = new List<sObject>();
-        for (User u : loginUsers) {
-            scope.add((sObject)u);
-        }
-        
-        batch.execute(bc, scope);
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed login user upgrade path');
+
+    if (!loginHistoryRecords.isEmpty()) {
+      insert loginHistoryRecords;
     }
-    
-    @isTest
-    static void testBatchTargetCalculatedFlag() {
-        // Test the targetCalculated flag and recalculation logic
-        // This tests the branch: allUsers.size() > premiumUsersToKeep.size() * 1.5
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Execute multiple times with empty scopes to set up state
-        // This will set targetCalculated = true after first calculation
-        batch.execute(bc, new List<sObject>());
-        batch.execute(bc, new List<sObject>());
-        
-        // Execute again to potentially trigger recalculation
-        batch.execute(bc, new List<sObject>());
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch handled targetCalculated flag');
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    List<sObject> scope = new List<sObject>();
+    for (User u : loginUsers) {
+      scope.add((sObject) u);
     }
-    
-    @isTest
-    static void testBatchWithExactThresholdLogins() {
-        // Test users with exactly 5 logins (threshold is >5, so they should NOT qualify)
-        List<User> communityUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-            LIMIT 5
-        ];
-        
-        if (communityUsers.isEmpty()) {
-            return;
-        }
-        
-        // Create exactly 5 login records for each user (threshold is >5)
-        List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
-        Integer currentYear = Date.today().year();
-        Integer currentMonth = Date.today().month();
-        Date fiscalYearStart;
-        
-        if (currentMonth >= 2 && currentMonth <= 4) {
-            fiscalYearStart = Date.today().addDays(-365);
-        } else if (currentMonth >= 5) {
-            fiscalYearStart = Date.newInstance(currentYear, 2, 1);
-        } else {
-            fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
-        }
-        
-        Integer recordCounter = 12000;
-        for (Integer userIdx = 0; userIdx < communityUsers.size(); userIdx++) {
-            // Create exactly 5 logins (threshold is >5, so these users should NOT get Premium)
-            for (Integer i = 0; i < 5; i++) {
-                String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
-                Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                    Login_History_Id__c = uniqueId,
-                    User__c = communityUsers[userIdx].Id,
-                    Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(i), Time.newInstance(0, 0, 0, 0))
-                );
-                loginHistoryRecords.add(record);
-            }
-        }
-        
-        if (!loginHistoryRecords.isEmpty()) {
-            insert loginHistoryRecords;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        List<sObject> scope = new List<sObject>();
-        for (User u : communityUsers) {
-            scope.add((sObject)u);
-        }
-        
-        batch.execute(bc, scope);
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed with exact threshold logins');
+
+    batch.execute(bc, scope);
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed login user upgrade path');
+  }
+
+  @isTest
+  static void testBatchTargetCalculatedFlag() {
+    // Test the targetCalculated flag and recalculation logic
+    // This tests the branch: allUsers.size() > premiumUsersToKeep.size() * 1.5
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    // Execute multiple times with empty scopes to set up state
+    // This will set targetCalculated = true after first calculation
+    batch.execute(bc, new List<sObject>());
+    batch.execute(bc, new List<sObject>());
+
+    // Execute again to potentially trigger recalculation
+    batch.execute(bc, new List<sObject>());
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch handled targetCalculated flag');
+  }
+
+  @isTest
+  static void testBatchWithExactThresholdLogins() {
+    // Test users with exactly 5 logins (threshold is >5, so they should NOT qualify)
+    List<User> communityUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name IN (
+          'Customer Community Plus',
+          'Customer Community Plus Login'
+        )
+      LIMIT 5
+    ];
+
+    if (communityUsers.isEmpty()) {
+      return;
     }
-    
-    @isTest
-    static void testBatchWithSixLogins() {
-        // Test users with exactly 6 logins (threshold is >5, so they SHOULD qualify)
-        List<User> communityUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-            LIMIT 5
-        ];
-        
-        if (communityUsers.isEmpty()) {
-            return;
-        }
-        
-        // Create exactly 6 login records for each user (threshold is >5, so these users SHOULD get Premium)
-        List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
-        Integer currentYear = Date.today().year();
-        Integer currentMonth = Date.today().month();
-        Date fiscalYearStart;
-        
-        if (currentMonth >= 2 && currentMonth <= 4) {
-            fiscalYearStart = Date.today().addDays(-365);
-        } else if (currentMonth >= 5) {
-            fiscalYearStart = Date.newInstance(currentYear, 2, 1);
-        } else {
-            fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
-        }
-        
-        Integer recordCounter = 13000;
-        for (Integer userIdx = 0; userIdx < communityUsers.size(); userIdx++) {
-            // Create exactly 6 logins (threshold is >5, so these users SHOULD get Premium)
-            for (Integer i = 0; i < 6; i++) {
-                String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
-                Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                    Login_History_Id__c = uniqueId,
-                    User__c = communityUsers[userIdx].Id,
-                    Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(i), Time.newInstance(0, 0, 0, 0))
-                );
-                loginHistoryRecords.add(record);
-            }
-        }
-        
-        if (!loginHistoryRecords.isEmpty()) {
-            insert loginHistoryRecords;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        List<sObject> scope = new List<sObject>();
-        for (User u : communityUsers) {
-            scope.add((sObject)u);
-        }
-        
-        batch.execute(bc, scope);
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed with six logins (above threshold)');
+
+    // Create exactly 5 login records for each user (threshold is >5)
+    List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
+    Integer currentYear = Date.today().year();
+    Integer currentMonth = Date.today().month();
+    Date fiscalYearStart;
+
+    if (currentMonth >= 2 && currentMonth <= 4) {
+      fiscalYearStart = Date.today().addDays(-365);
+    } else if (currentMonth >= 5) {
+      fiscalYearStart = Date.newInstance(currentYear, 2, 1);
+    } else {
+      fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
     }
-    
-    @isTest
-    static void testBatchComparatorLogic() {
-        // Test the UserLoginCountComparator sorting logic with users having different login counts
-        List<User> communityUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-            LIMIT 8
-        ];
-        
-        if (communityUsers.isEmpty()) {
-            return;
-        }
-        
-        // Create login history with varying counts to test sorting (descending by login count)
-        List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
-        Integer currentYear = Date.today().year();
-        Integer currentMonth = Date.today().month();
-        Date fiscalYearStart;
-        
-        if (currentMonth >= 2 && currentMonth <= 4) {
-            fiscalYearStart = Date.today().addDays(-365);
-        } else if (currentMonth >= 5) {
-            fiscalYearStart = Date.newInstance(currentYear, 2, 1);
-        } else {
-            fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
-        }
-        
-        Integer recordCounter = 14000;
-        // Create varying login counts: 20, 15, 10, 8, 7, 6, 4, 3
-        List<Integer> loginCounts = new List<Integer>{20, 15, 10, 8, 7, 6, 4, 3};
-        for (Integer userIdx = 0; userIdx < communityUsers.size() && userIdx < loginCounts.size(); userIdx++) {
-            Integer loginCount = loginCounts[userIdx];
-            for (Integer i = 0; i < loginCount; i++) {
-                String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
-                Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
-                    Login_History_Id__c = uniqueId,
-                    User__c = communityUsers[userIdx].Id,
-                    Login_Time__c = DateTime.newInstance(fiscalYearStart.addDays(i), Time.newInstance(0, 0, 0, 0))
-                );
-                loginHistoryRecords.add(record);
-            }
-        }
-        
-        if (!loginHistoryRecords.isEmpty()) {
-            insert loginHistoryRecords;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        List<sObject> scope = new List<sObject>();
-        for (User u : communityUsers) {
-            scope.add((sObject)u);
-        }
-        
-        batch.execute(bc, scope);
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed with comparator sorting logic');
+
+    Integer recordCounter = 12000;
+    for (Integer userIdx = 0; userIdx < communityUsers.size(); userIdx++) {
+      // Create exactly 5 logins (threshold is >5, so these users should NOT get Premium)
+      for (Integer i = 0; i < 5; i++) {
+        String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
+        Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+          Login_History_Id__c = uniqueId,
+          User__c = communityUsers[userIdx].Id,
+          Login_Time__c = DateTime.newInstance(
+            fiscalYearStart.addDays(i),
+            Time.newInstance(0, 0, 0, 0)
+          )
+        );
+        loginHistoryRecords.add(record);
+      }
     }
-    
-    @isTest
-    static void testBatchWithZeroLogins() {
-        // Test users with zero logins
-        List<User> communityUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-            LIMIT 3
-        ];
-        
-        if (communityUsers.isEmpty()) {
-            return;
-        }
-        
-        // Don't create any login history - users will have 0 logins
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        List<sObject> scope = new List<sObject>();
-        for (User u : communityUsers) {
-            scope.add((sObject)u);
-        }
-        
-        batch.execute(bc, scope);
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed with zero logins');
+
+    if (!loginHistoryRecords.isEmpty()) {
+      insert loginHistoryRecords;
     }
-    
-    @isTest
-    static void testBatchFinishWithNoChangeLogs() {
-        // Test finish method when there are no change logs
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        // Execute with empty scope - no changes, so no logs
-        batch.execute(bc, new List<sObject>());
-        batch.finish(bc);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch finish executed with no change logs');
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    List<sObject> scope = new List<sObject>();
+    for (User u : communityUsers) {
+      scope.add((sObject) u);
     }
-    
-    @isTest
-    static void testBatchWithNullCreatedDate() {
-        // Test isNewUser method with null CreatedDate
-        List<User> communityUsers = [
-            SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
-            FROM User
-            WHERE IsActive = true
-            AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
-            LIMIT 3
-        ];
-        
-        if (communityUsers.isEmpty()) {
-            return;
-        }
-        
-        Test.startTest();
-        LicenseShuffleBatch batch = new LicenseShuffleBatch();
-        Database.BatchableContext bc = new TestBatchableContext();
-        
-        List<sObject> scope = new List<sObject>();
-        for (User u : communityUsers) {
-            scope.add((sObject)u);
-        }
-        
-        batch.execute(bc, scope);
-        Test.stopTest();
-        
-        System.assert(true, 'Batch executed with users (testing null CreatedDate handling)');
+
+    batch.execute(bc, scope);
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed with exact threshold logins');
+  }
+
+  @isTest
+  static void testBatchWithSixLogins() {
+    // Test users with exactly 6 logins (threshold is >5, so they SHOULD qualify)
+    List<User> communityUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name IN (
+          'Customer Community Plus',
+          'Customer Community Plus Login'
+        )
+      LIMIT 5
+    ];
+
+    if (communityUsers.isEmpty()) {
+      return;
     }
-    
-    /**
-     * Helper method to get a test user
-     */
-    private static User getTestUser() {
-        List<User> users = [
-            SELECT Id 
-            FROM User 
-            WHERE IsActive = true 
-            LIMIT 1
-        ];
-        return users.isEmpty() ? null : users[0];
+
+    // Create exactly 6 login records for each user (threshold is >5, so these users SHOULD get Premium)
+    List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
+    Integer currentYear = Date.today().year();
+    Integer currentMonth = Date.today().month();
+    Date fiscalYearStart;
+
+    if (currentMonth >= 2 && currentMonth <= 4) {
+      fiscalYearStart = Date.today().addDays(-365);
+    } else if (currentMonth >= 5) {
+      fiscalYearStart = Date.newInstance(currentYear, 2, 1);
+    } else {
+      fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
     }
-    
-    /**
-     * Helper class to create a test BatchableContext
-     */
-    private class TestBatchableContext implements Database.BatchableContext {
-        private Id jobId;
-        
-        public TestBatchableContext() {
-            this.jobId = UserInfo.getUserId();
-        }
-        
-        public TestBatchableContext(Id jobId) {
-            this.jobId = jobId;
-        }
-        
-        public Id getJobId() {
-            return jobId;
-        }
-        
-        public Id getChildJobId() {
-            return null;
-        }
+
+    Integer recordCounter = 13000;
+    for (Integer userIdx = 0; userIdx < communityUsers.size(); userIdx++) {
+      // Create exactly 6 logins (threshold is >5, so these users SHOULD get Premium)
+      for (Integer i = 0; i < 6; i++) {
+        String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
+        Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+          Login_History_Id__c = uniqueId,
+          User__c = communityUsers[userIdx].Id,
+          Login_Time__c = DateTime.newInstance(
+            fiscalYearStart.addDays(i),
+            Time.newInstance(0, 0, 0, 0)
+          )
+        );
+        loginHistoryRecords.add(record);
+      }
     }
+
+    if (!loginHistoryRecords.isEmpty()) {
+      insert loginHistoryRecords;
+    }
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    List<sObject> scope = new List<sObject>();
+    for (User u : communityUsers) {
+      scope.add((sObject) u);
+    }
+
+    batch.execute(bc, scope);
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed with six logins (above threshold)');
+  }
+
+  @isTest
+  static void testBatchComparatorLogic() {
+    // Test the UserLoginCountComparator sorting logic with users having different login counts
+    List<User> communityUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name IN (
+          'Customer Community Plus',
+          'Customer Community Plus Login'
+        )
+      LIMIT 8
+    ];
+
+    if (communityUsers.isEmpty()) {
+      return;
+    }
+
+    // Create login history with varying counts to test sorting (descending by login count)
+    List<Fiscal_Year_Login_History__c> loginHistoryRecords = new List<Fiscal_Year_Login_History__c>();
+    Integer currentYear = Date.today().year();
+    Integer currentMonth = Date.today().month();
+    Date fiscalYearStart;
+
+    if (currentMonth >= 2 && currentMonth <= 4) {
+      fiscalYearStart = Date.today().addDays(-365);
+    } else if (currentMonth >= 5) {
+      fiscalYearStart = Date.newInstance(currentYear, 2, 1);
+    } else {
+      fiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
+    }
+
+    Integer recordCounter = 14000;
+    // Create varying login counts: 20, 15, 10, 8, 7, 6, 4, 3
+    List<Integer> loginCounts = new List<Integer>{ 20, 15, 10, 8, 7, 6, 4, 3 };
+    for (
+      Integer userIdx = 0;
+      userIdx < communityUsers.size() &&
+      userIdx < loginCounts.size();
+      userIdx++
+    ) {
+      Integer loginCount = loginCounts[userIdx];
+      for (Integer i = 0; i < loginCount; i++) {
+        String uniqueId = String.valueOf(recordCounter++).leftPad(18, '0');
+        Fiscal_Year_Login_History__c record = new Fiscal_Year_Login_History__c(
+          Login_History_Id__c = uniqueId,
+          User__c = communityUsers[userIdx].Id,
+          Login_Time__c = DateTime.newInstance(
+            fiscalYearStart.addDays(i),
+            Time.newInstance(0, 0, 0, 0)
+          )
+        );
+        loginHistoryRecords.add(record);
+      }
+    }
+
+    if (!loginHistoryRecords.isEmpty()) {
+      insert loginHistoryRecords;
+    }
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    List<sObject> scope = new List<sObject>();
+    for (User u : communityUsers) {
+      scope.add((sObject) u);
+    }
+
+    batch.execute(bc, scope);
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed with comparator sorting logic');
+  }
+
+  @isTest
+  static void testBatchWithZeroLogins() {
+    // Test users with zero logins
+    List<User> communityUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name IN (
+          'Customer Community Plus',
+          'Customer Community Plus Login'
+        )
+      LIMIT 3
+    ];
+
+    if (communityUsers.isEmpty()) {
+      return;
+    }
+
+    // Don't create any login history - users will have 0 logins
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    List<sObject> scope = new List<sObject>();
+    for (User u : communityUsers) {
+      scope.add((sObject) u);
+    }
+
+    batch.execute(bc, scope);
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch executed with zero logins');
+  }
+
+  @isTest
+  static void testBatchFinishWithNoChangeLogs() {
+    // Test finish method when there are no change logs
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    // Execute with empty scope - no changes, so no logs
+    batch.execute(bc, new List<sObject>());
+    batch.finish(bc);
+    Test.stopTest();
+
+    System.assert(true, 'Batch finish executed with no change logs');
+  }
+
+  @isTest
+  static void testBatchWithNullCreatedDate() {
+    // Test isNewUser method with null CreatedDate
+    List<User> communityUsers = [
+      SELECT Id, Profile.UserLicense.Name, Profile.Name, CreatedDate
+      FROM User
+      WHERE
+        IsActive = TRUE
+        AND Profile.UserLicense.Name IN (
+          'Customer Community Plus',
+          'Customer Community Plus Login'
+        )
+      LIMIT 3
+    ];
+
+    if (communityUsers.isEmpty()) {
+      return;
+    }
+
+    Test.startTest();
+    LicenseShuffleBatch batch = new LicenseShuffleBatch();
+    Database.BatchableContext bc = new TestBatchableContext();
+
+    List<sObject> scope = new List<sObject>();
+    for (User u : communityUsers) {
+      scope.add((sObject) u);
+    }
+
+    batch.execute(bc, scope);
+    Test.stopTest();
+
+    System.assert(
+      true,
+      'Batch executed with users (testing null CreatedDate handling)'
+    );
+  }
+
+  /**
+   * Helper method to get a test user
+   */
+  private static User getTestUser() {
+    List<User> users = [
+      SELECT Id
+      FROM User
+      WHERE IsActive = TRUE
+      LIMIT 1
+    ];
+    return users.isEmpty() ? null : users[0];
+  }
+
+  /**
+   * Helper class to create a test BatchableContext
+   */
+  private class TestBatchableContext implements Database.BatchableContext {
+    private Id jobId;
+
+    public TestBatchableContext() {
+      this.jobId = UserInfo.getUserId();
+    }
+
+    public TestBatchableContext(Id jobId) {
+      this.jobId = jobId;
+    }
+
+    public Id getJobId() {
+      return jobId;
+    }
+
+    public Id getChildJobId() {
+      return null;
+    }
+  }
 }

--- a/force-app/main/default/classes/LoginHistoryCleanupBatch.cls
+++ b/force-app/main/default/classes/LoginHistoryCleanupBatch.cls
@@ -1,77 +1,100 @@
 /**
  * Batch class to clean up old Fiscal_Year_Login_History__c records.
- * 
+ *
  * Runs on May 1st to delete records before February 1st of the previous fiscal year.
  * This keeps exactly one full fiscal year of data (Feb 1 - Jan 31).
  */
-public class LoginHistoryCleanupBatch implements Database.Batchable<sObject> {
-    
-    private Integer totalRecordsDeleted = 0;
-    private Integer totalErrors = 0;
-    
-    /**
-     * Batch start method - queries records to delete
-     */
-    public Database.QueryLocator start(Database.BatchableContext bc) {
-        System.debug('LoginHistoryCleanupBatch: Starting cleanup job ' + bc.getJobId());
-        
-        // Calculate previous fiscal year start: February 1st of previous year
-        Integer currentYear = Date.today().year();
-        Date previousFiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
-        DateTime cutoffDateTime = DateTime.newInstance(previousFiscalYearStart, Time.newInstance(0, 0, 0, 0));
-        
-        System.debug('LoginHistoryCleanupBatch: Deleting records before ' + cutoffDateTime);
-        
-        // Query records to delete (before Feb 1 of previous fiscal year)
-        return Database.getQueryLocator([
-            SELECT Id
-            FROM Fiscal_Year_Login_History__c
-            WHERE Login_Time__c < :cutoffDateTime
-        ]);
-    }
-    
-    /**
-     * Batch execute method - deletes old records
-     */
-    public void execute(Database.BatchableContext bc, List<sObject> scope) {
-        if (scope == null || scope.isEmpty()) {
-            System.debug('LoginHistoryCleanupBatch: No records to delete in this batch');
-            return;
-        }
-        
-        List<Fiscal_Year_Login_History__c> recordsToDelete = new List<Fiscal_Year_Login_History__c>();
-        for (sObject obj : scope) {
-            recordsToDelete.add((Fiscal_Year_Login_History__c)obj);
-        }
-        
-        try {
-            Database.DeleteResult[] results = Database.delete(recordsToDelete, false); // Allow partial success
-            
-            Integer successCount = 0;
-            for (Database.DeleteResult result : results) {
-                if (result.isSuccess()) {
-                    successCount++;
-                } else {
-                    totalErrors++;
-                    System.debug('LoginHistoryCleanupBatch: Delete error: ' + result.getErrors());
-                }
-            }
-            totalRecordsDeleted += successCount;
-            System.debug('LoginHistoryCleanupBatch: Deleted ' + successCount + ' of ' + recordsToDelete.size() + ' records in this batch');
-        } catch (Exception e) {
-            totalErrors++;
-            System.debug('LoginHistoryCleanupBatch: Error during delete: ' + e.getMessage());
-            System.debug('LoginHistoryCleanupBatch: Stack trace: ' + e.getStackTraceString());
-        }
-    }
-    
-    /**
-     * Batch finish method - logs statistics
-     */
-    public void finish(Database.BatchableContext bc) {
-        System.debug('LoginHistoryCleanupBatch: Cleanup job completed');
-        System.debug('LoginHistoryCleanupBatch: Total records deleted: ' + totalRecordsDeleted);
-        System.debug('LoginHistoryCleanupBatch: Total errors: ' + totalErrors);
-    }
-}
+public class LoginHistoryCleanupBatch implements Database.Batchable<sObject>, Database.Stateful {
+  private Integer totalRecordsDeleted = 0;
+  private Integer totalErrors = 0;
 
+  /**
+   * Batch start method - queries records to delete
+   */
+  public Database.QueryLocator start(Database.BatchableContext bc) {
+    System.debug(
+      'LoginHistoryCleanupBatch: Starting cleanup job ' + bc.getJobId()
+    );
+
+    // Calculate previous fiscal year start: February 1st of previous year
+    Integer currentYear = Date.today().year();
+    Date previousFiscalYearStart = Date.newInstance(currentYear - 1, 2, 1);
+    DateTime cutoffDateTime = DateTime.newInstance(
+      previousFiscalYearStart,
+      Time.newInstance(0, 0, 0, 0)
+    );
+
+    System.debug(
+      'LoginHistoryCleanupBatch: Deleting records before ' + cutoffDateTime
+    );
+
+    // Query records to delete (before Feb 1 of previous fiscal year)
+    return Database.getQueryLocator(
+      [
+        SELECT Id
+        FROM Fiscal_Year_Login_History__c
+        WHERE Login_Time__c < :cutoffDateTime
+      ]
+    );
+  }
+
+  /**
+   * Batch execute method - deletes old records
+   */
+  public void execute(Database.BatchableContext bc, List<sObject> scope) {
+    if (scope == null || scope.isEmpty()) {
+      System.debug(
+        'LoginHistoryCleanupBatch: No records to delete in this batch'
+      );
+      return;
+    }
+
+    List<Fiscal_Year_Login_History__c> recordsToDelete = new List<Fiscal_Year_Login_History__c>();
+    for (sObject obj : scope) {
+      recordsToDelete.add((Fiscal_Year_Login_History__c) obj);
+    }
+
+    try {
+      Database.DeleteResult[] results = Database.delete(recordsToDelete, false); // Allow partial success
+
+      Integer successCount = 0;
+      for (Database.DeleteResult result : results) {
+        if (result.isSuccess()) {
+          successCount++;
+        } else {
+          totalErrors++;
+          System.debug(
+            'LoginHistoryCleanupBatch: Delete error: ' + result.getErrors()
+          );
+        }
+      }
+      totalRecordsDeleted += successCount;
+      System.debug(
+        'LoginHistoryCleanupBatch: Deleted ' +
+          successCount +
+          ' of ' +
+          recordsToDelete.size() +
+          ' records in this batch'
+      );
+    } catch (Exception e) {
+      totalErrors++;
+      System.debug(
+        'LoginHistoryCleanupBatch: Error during delete: ' + e.getMessage()
+      );
+      System.debug(
+        'LoginHistoryCleanupBatch: Stack trace: ' + e.getStackTraceString()
+      );
+    }
+  }
+
+  /**
+   * Batch finish method - logs statistics
+   */
+  public void finish(Database.BatchableContext bc) {
+    System.debug('LoginHistoryCleanupBatch: Cleanup job completed');
+    System.debug(
+      'LoginHistoryCleanupBatch: Total records deleted: ' + totalRecordsDeleted
+    );
+    System.debug('LoginHistoryCleanupBatch: Total errors: ' + totalErrors);
+  }
+}

--- a/scripts/apex/license-sorting/emergency_downgrade_bottom_30.apex
+++ b/scripts/apex/license-sorting/emergency_downgrade_bottom_30.apex
@@ -1,0 +1,138 @@
+/**
+ * Emergency script: downgrade the 30 non-protected Premium users with the lowest
+ * fiscal-year login counts to Customer Community Plus Login.
+ *
+ * Run this in Anonymous Apex when the Premium license cap (475) has been exceeded.
+ *
+ * Safe to re-run — users already on Login license are excluded from the query.
+ */
+
+System.debug('=== Emergency License Downgrade: Bottom 30 ===');
+
+// --- Fiscal year date range (matches LicenseShuffleBatch.countUserLogins logic) ---
+Integer currentMonth = Date.today().month();
+Integer currentYear = Date.today().year();
+Date startDate;
+if (currentMonth >= 2 && currentMonth <= 4) {
+    startDate = Date.today().addDays(-365);
+} else if (currentMonth >= 5) {
+    startDate = Date.newInstance(currentYear, 2, 1);
+} else {
+    startDate = Date.newInstance(currentYear - 1, 2, 1);
+}
+DateTime startDT = DateTime.newInstance(startDate, Time.newInstance(0, 0, 0, 0));
+System.debug('Fiscal period start: ' + startDate);
+
+// --- Build login count map from Fiscal_Year_Login_History__c ---
+AggregateResult[] loginAggs = [
+    SELECT User__c uid, COUNT(Id) cnt
+    FROM Fiscal_Year_Login_History__c
+    WHERE Login_Time__c >= :startDT
+    GROUP BY User__c
+];
+Map<Id, Integer> loginMap = new Map<Id, Integer>();
+for (AggregateResult ar : loginAggs) {
+    loginMap.put((Id)ar.get('uid'), (Integer)ar.get('cnt'));
+}
+System.debug('Users with login records: ' + loginMap.size());
+
+// --- Query all non-protected active Premium users ---
+Date cutoff = Date.today().addDays(-90);
+DateTime cutoffDT = DateTime.newInstance(cutoff, Time.newInstance(0, 0, 0, 0));
+List<User> premiumUsers = [
+    SELECT Id, Name, Profile.Name, Profile.UserLicense.Name, CreatedDate
+    FROM User
+    WHERE IsActive = true
+    AND Profile.UserLicense.Name = 'Customer Community Plus'
+    AND Profile.Name != 'SM Community Plus Chair'
+    AND CreatedDate < :cutoffDT
+];
+System.debug('Non-protected Premium users: ' + premiumUsers.size());
+
+// --- Sort by login count ascending ---
+premiumUsers.sort(new AscLoginCountComparator(loginMap));
+
+// --- Take the bottom 30 ---
+Integer TARGET = 30;
+List<User> toDowngrade = new List<User>();
+System.debug('--- Bottom 30 users to downgrade ---');
+for (Integer i = 0; i < Math.min(TARGET, premiumUsers.size()); i++) {
+    User u = premiumUsers[i];
+    Integer cnt = loginMap.containsKey(u.Id) ? loginMap.get(u.Id) : 0;
+    System.debug((i + 1) + '. ' + u.Name + ' | Logins: ' + cnt + ' | Created: ' + u.CreatedDate.date());
+    toDowngrade.add(u);
+}
+
+if (toDowngrade.isEmpty()) {
+    System.debug('No users to downgrade. Exiting.');
+    return;
+}
+
+// --- Look up the Login profile ID ---
+Profile loginProfile = [SELECT Id FROM Profile WHERE Name = 'SM Community Plus Login' LIMIT 1];
+System.debug('Login profile ID: ' + loginProfile.Id);
+
+// --- Build user updates and change log records ---
+List<User> usersToUpdate = new List<User>();
+List<License_Change_Log__c> logs = new List<License_Change_Log__c>();
+String jobId = 'EMERGENCY-' + DateTime.now().format('yyyyMMdd-HHmmss');
+
+for (User u : toDowngrade) {
+    Integer cnt = loginMap.containsKey(u.Id) ? loginMap.get(u.Id) : 0;
+    User upd = new User(Id = u.Id, ProfileId = loginProfile.Id);
+    usersToUpdate.add(upd);
+    logs.add(new License_Change_Log__c(
+        User__c = u.Id,
+        Old_License__c = 'Customer Community Plus',
+        New_License__c = 'Customer Community Plus Login',
+        Old_Profile__c = u.Profile.Name,
+        New_Profile__c = 'SM Community Plus Login',
+        Login_Count__c = cnt,
+        Reason__c = 'Emergency downgrade - license cap exceeded',
+        Changed_At__c = DateTime.now(),
+        Batch_Job_Id__c = jobId
+    ));
+}
+
+// --- Apply user updates ---
+try {
+    update usersToUpdate;
+    System.debug('SUCCESS: Downgraded ' + usersToUpdate.size() + ' users to Login license');
+} catch (Exception e) {
+    System.debug('ERROR updating users: ' + e.getMessage());
+    throw e;
+}
+
+// --- Enqueue log insertion (avoids MIXED_DML_OPERATION) ---
+try {
+    LicenseChangeLogQueueable q = new LicenseChangeLogQueueable(logs);
+    System.enqueueJob(q);
+    System.debug('Change logs queued for insertion (' + logs.size() + ' records)');
+} catch (Exception e) {
+    System.debug('WARNING: Could not queue change logs: ' + e.getMessage());
+}
+
+// --- Verification query ---
+AggregateResult[] after = [
+    SELECT Profile.UserLicense.Name lic, COUNT(Id) cnt
+    FROM User
+    WHERE IsActive = true
+    AND Profile.UserLicense.Name IN ('Customer Community Plus', 'Customer Community Plus Login')
+    GROUP BY Profile.UserLicense.Name
+];
+System.debug('--- License counts after downgrade ---');
+for (AggregateResult r : after) {
+    System.debug(r.get('lic') + ': ' + r.get('cnt'));
+}
+System.debug('=== Done ===');
+
+// --- Sort helper ---
+class AscLoginCountComparator implements Comparator<User> {
+    private Map<Id, Integer> counts;
+    AscLoginCountComparator(Map<Id, Integer> counts) { this.counts = counts; }
+    public Integer compare(User a, User b) {
+        Integer ca = counts.containsKey(a.Id) ? counts.get(a.Id) : 0;
+        Integer cb = counts.containsKey(b.Id) ? counts.get(b.Id) : 0;
+        return ca < cb ? -1 : (ca > cb ? 1 : 0);
+    }
+}


### PR DESCRIPTION
## Summary

- **Emergency**: Premium licenses hit the hard cap (505/505). Downgraded the 30 lowest-login non-protected Premium users via `emergency_downgrade_bottom_30.apex`. Cap is now 444 (well under 475).
- **Root cause**: `LicenseShuffleBatch` made license decisions per-chunk, before all users had been seen. The `calculatePremiumUsersToKeep()` method ran in `execute()` on incomplete data.
- **Fix**: Two-pass design — `execute()` collects all users and login counts, `finish()` has the full picture before making any decisions or DML.
- **Bonus fix**: `LoginHistoryCleanupBatch` was missing `Database.Stateful`, so its `finish()` delete count always reported 0.

## Changes

- `LicenseShuffleBatch` — collection/action split; aggregate login count query per chunk (was 50 SOQL queries/chunk, now 1); profile IDs cached in `finish()`; dead code removed
- `LicenseShuffleBatchTest` — removed 4 tests targeting dead-code branches; 240/240 passing
- `LoginHistoryCleanupBatch` — added `Database.Stateful`
- `emergency_downgrade_bottom_30.apex` — new script for future license cap recovery
- Docs — proposal updated to reflect live status; fix plan added

## Test plan

- [x] 240/240 org tests passing after deploy
- [x] Emergency script ran successfully: Premium 505 → 444
- [x] Daily sync scheduler restored to original cron (`0 0 2 * * ?`, 2 AM Pacific)
- [ ] Verify next batch run (2026-04-13 02:00 AM Pacific) reaches steady state